### PR TITLE
[refactor] Thymeleaf 에러 페이지를 default_layout 기반으로 리팩터링

### DIFF
--- a/src/main/resources/templates/error/400.html
+++ b/src/main/resources/templates/error/400.html
@@ -1,268 +1,40 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/default_layout}">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>400 - 잘못된 요청 | Knoc</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <style>
-        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-        :root {
-            --bg-primary: #0d1117;
-            --bg-card: #161b22;
-            --bg-card-inner: #1c2128;
-            --border: rgba(48, 54, 61, 0.8);
-            --text-primary: #e6edf3;
-            --text-secondary: #8b949e;
-            --text-muted: #6e7681;
-            --accent: #00c8c8;
-            --accent-dim: rgba(0, 200, 200, 0.12);
-            --accent-border: rgba(0, 200, 200, 0.35);
-            --error-color: #e8a838;
-            --error-dim: rgba(232, 168, 56, 0.12);
-            --error-border: rgba(232, 168, 56, 0.35);
-            --btn-ghost-border: rgba(139, 148, 158, 0.3);
-            --btn-ghost-hover: rgba(139, 148, 158, 0.08);
-        }
-
-        body {
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans KR', sans-serif;
-            min-height: 100vh;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            padding: 2rem 1.5rem;
-        }
-
-        /* Subtle grid background */
-        body::before {
-            content: '';
-            position: fixed;
-            inset: 0;
-            background-image:
-                linear-gradient(rgba(0,200,200,0.03) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(0,200,200,0.03) 1px, transparent 1px);
-            background-size: 60px 60px;
-            pointer-events: none;
-            z-index: 0;
-        }
-
-        .container {
-            position: relative;
-            z-index: 1;
-            width: 100%;
-            max-width: 560px;
-            text-align: center;
-        }
-
-        /* Logo */
-        .logo {
-            display: inline-flex;
-            align-items: center;
-            gap: 10px;
-            margin-bottom: 3rem;
-            text-decoration: none;
-        }
-
-        .logo-mark {
-            width: 36px;
-            height: 36px;
-            background: var(--accent);
-            border-radius: 8px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-weight: 700;
-            font-size: 15px;
-            color: #0d1117;
-            letter-spacing: -0.5px;
-        }
-
-        .logo-text {
-            font-size: 20px;
-            font-weight: 700;
-            color: var(--text-primary);
-            letter-spacing: -0.5px;
-        }
-
-        /* Error card */
-        .error-card {
-            background: var(--bg-card);
-            border: 1px solid var(--border);
-            border-radius: 16px;
-            padding: 2.5rem 2rem;
-        }
-
-        /* Icon area */
-        .icon-wrap {
-            width: 80px;
-            height: 80px;
-            margin: 0 auto 1.5rem;
-            background: var(--error-dim);
-            border: 1px solid var(--error-border);
-            border-radius: 20px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .icon-wrap i {
-            font-size: 36px;
-            color: var(--error-color);
-        }
-
-        /* Error code */
-        .error-code {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 2px;
-            text-transform: uppercase;
-            color: var(--error-color);
-            margin-bottom: 0.75rem;
-        }
-
-        /* Title */
-        .error-title {
-            font-size: 26px;
-            font-weight: 700;
-            color: var(--text-primary);
-            line-height: 1.3;
-            margin-bottom: 1rem;
-        }
-
-        /* Description */
-        .error-desc {
-            font-size: 15px;
-            color: var(--text-secondary);
-            line-height: 1.7;
-            margin-bottom: 0;
-        }
-
-        /* Message from server */
-        .server-message {
-            margin-top: 1.25rem;
-            padding: 0.875rem 1rem;
-            background: var(--bg-card-inner);
-            border: 1px solid var(--border);
-            border-left: 3px solid var(--error-color);
-            border-radius: 8px;
-            font-size: 13px;
-            color: var(--text-secondary);
-            text-align: left;
-            line-height: 1.6;
-        }
-
-        .server-message .msg-label {
-            font-size: 11px;
-            font-weight: 600;
-            letter-spacing: 1px;
-            text-transform: uppercase;
-            color: var(--text-muted);
-            margin-bottom: 4px;
-        }
-
-        /* Divider */
-        .divider {
-            height: 1px;
-            background: var(--border);
-            margin: 2rem 0;
-        }
-
-        /* Buttons */
-        .btn-group {
-            display: flex;
-            gap: 12px;
-            justify-content: center;
-        }
-
-        .btn {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            padding: 0.65rem 1.4rem;
-            font-size: 14px;
-            font-weight: 600;
-            border-radius: 8px;
-            border: none;
-            cursor: pointer;
-            text-decoration: none;
-            transition: opacity 0.15s, background 0.15s;
-        }
-
-        .btn-primary {
-            background: var(--accent);
-            color: #0d1117;
-        }
-
-        .btn-primary:hover { opacity: 0.88; }
-
-        .btn-ghost {
-            background: transparent;
-            color: var(--text-secondary);
-            border: 1px solid var(--btn-ghost-border);
-        }
-
-        .btn-ghost:hover {
-            background: var(--btn-ghost-hover);
-            color: var(--text-primary);
-        }
-
-
-        @media (max-width: 480px) {
-            .btn-group { flex-direction: column; }
-            .btn { justify-content: center; }
-            .error-title { font-size: 22px; }
-        }
-    </style>
+    <title>400 - 잘못된 요청</title>
+    <th:block layout:fragment="head-extra">
+        <th:block th:replace="~{fragments/error_page_head :: errorPageHead}"></th:block>
+    </th:block>
 </head>
-<body>
-
-<div class="container">
-
-    <a href="/" class="logo">
-        <div class="logo-mark">K</div>
-        <span class="logo-text">Knoc.</span>
-    </a>
-
-    <div class="error-card">
-
-        <div class="icon-wrap">
-            <i class="bi bi-exclamation-triangle"></i>
+<div layout:fragment="content">
+    <section class="container py-5 my-lg-4">
+        <div class="error-shell px-3">
+            <div class="card card-dark rounded-4 border-secondary text-center p-4 p-md-5">
+                <div class="error-icon-wrap error-icon-wrap--amber">
+                    <i class="bi bi-exclamation-triangle" aria-hidden="true"></i>
+                </div>
+                <p class="error-code-label text-warning mb-2">Error 400</p>
+                <h1 class="h3 fw-bold text-white mb-3">잘못된 요청이에요</h1>
+                <p class="text-secondary mb-0">
+                    서버가 요청을 이해하지 못했어요.<br>
+                    입력하신 내용을 다시 한번 확인해 주세요.
+                </p>
+                <div class="alert alert-dark border border-secondary border-start border-warning border-3 text-start small mt-4 mb-0"
+                     th:if="${message != null and !#strings.isEmpty(message)}">
+                    <div class="text-uppercase text-muted fw-semibold mb-1" style="font-size: 0.7rem; letter-spacing: 0.08em;">상세 메시지</div>
+                    <span class="text-secondary" th:text="${message}"></span>
+                </div>
+                <hr class="border-secondary my-4">
+                <div class="d-flex flex-column flex-sm-row gap-2 justify-content-center">
+                    <a class="btn btn-mint rounded-3 px-4" th:href="@{/}">
+                        <i class="bi bi-house-fill me-1" aria-hidden="true"></i>메인으로 돌아가기
+                    </a>
+                    <button type="button" class="btn btn-outline-secondary error-ghost-btn rounded-3 px-4" onclick="history.back()">
+                        <i class="bi bi-arrow-left me-1" aria-hidden="true"></i>이전 페이지로
+                    </button>
+                </div>
+            </div>
         </div>
-
-        <p class="error-code">Error 400</p>
-        <h1 class="error-title">잘못된 요청이에요</h1>
-        <p class="error-desc">
-            서버가 요청을 이해하지 못했어요.<br>
-            입력하신 내용을 다시 한번 확인해 주세요.
-        </p>
-
-        <!-- Thymeleaf: server message (optional) -->
-        <div class="server-message" th:if="${message != null and !#strings.isEmpty(message)}">
-            <div class="msg-label">상세 메시지</div>
-            <span th:text="${message}"></span>
-        </div>
-
-        <div class="divider"></div>
-
-        <div class="btn-group">
-            <a href="/" class="btn btn-primary">
-                <i class="bi bi-house-fill" style="font-size:14px;"></i>
-                메인으로 돌아가기
-            </a>
-            <button onclick="history.back()" class="btn btn-ghost">
-                <i class="bi bi-arrow-left" style="font-size:14px;"></i>
-                이전 페이지로
-            </button>
-        </div>
-
-    </div>
-
+    </section>
 </div>
-
-</body>
 </html>

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -1,296 +1,47 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/default_layout}">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>403 - 접근 권한 없음 | Knoc</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <style>
-        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-        :root {
-            --bg-primary: #0d1117;
-            --bg-card: #161b22;
-            --bg-card-inner: #1c2128;
-            --border: rgba(48, 54, 61, 0.8);
-            --text-primary: #e6edf3;
-            --text-secondary: #8b949e;
-            --text-muted: #6e7681;
-            --accent: #00c8c8;
-            --error-color: #e05c5c;
-            --error-dim: rgba(224, 92, 92, 0.12);
-            --error-border: rgba(224, 92, 92, 0.35);
-            --btn-ghost-border: rgba(139, 148, 158, 0.3);
-            --btn-ghost-hover: rgba(139, 148, 158, 0.08);
-        }
-
-        body {
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans KR', sans-serif;
-            min-height: 100vh;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            padding: 2rem 1.5rem;
-        }
-
-        body::before {
-            content: '';
-            position: fixed;
-            inset: 0;
-            background-image:
-                linear-gradient(rgba(0,200,200,0.03) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(0,200,200,0.03) 1px, transparent 1px);
-            background-size: 60px 60px;
-            pointer-events: none;
-            z-index: 0;
-        }
-
-        .container {
-            position: relative;
-            z-index: 1;
-            width: 100%;
-            max-width: 560px;
-            text-align: center;
-        }
-
-        .logo {
-            display: inline-flex;
-            align-items: center;
-            gap: 10px;
-            margin-bottom: 3rem;
-            text-decoration: none;
-        }
-
-        .logo-mark {
-            width: 36px;
-            height: 36px;
-            background: var(--accent);
-            border-radius: 8px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-weight: 700;
-            font-size: 15px;
-            color: #0d1117;
-            letter-spacing: -0.5px;
-        }
-
-        .logo-text {
-            font-size: 20px;
-            font-weight: 700;
-            color: var(--text-primary);
-            letter-spacing: -0.5px;
-        }
-
-        .error-card {
-            background: var(--bg-card);
-            border: 1px solid var(--border);
-            border-radius: 16px;
-            padding: 2.5rem 2rem;
-        }
-
-        .icon-wrap {
-            width: 80px;
-            height: 80px;
-            margin: 0 auto 1.5rem;
-            background: var(--error-dim);
-            border: 1px solid var(--error-border);
-            border-radius: 20px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .icon-wrap i {
-            font-size: 36px;
-            color: var(--error-color);
-        }
-
-        .error-code {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 2px;
-            text-transform: uppercase;
-            color: var(--error-color);
-            margin-bottom: 0.75rem;
-        }
-
-        .error-title {
-            font-size: 26px;
-            font-weight: 700;
-            color: var(--text-primary);
-            line-height: 1.3;
-            margin-bottom: 1rem;
-        }
-
-        .error-desc {
-            font-size: 15px;
-            color: var(--text-secondary);
-            line-height: 1.7;
-        }
-
-        /* Login prompt box */
-        .login-prompt {
-            margin-top: 1.5rem;
-            padding: 1rem 1.25rem;
-            background: var(--bg-card-inner);
-            border: 1px solid rgba(0,200,200,0.2);
-            border-radius: 10px;
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            text-align: left;
-        }
-
-        .login-prompt i {
-            font-size: 20px;
-            color: var(--accent);
-            flex-shrink: 0;
-        }
-
-        .login-prompt-text {
-            font-size: 13px;
-            color: var(--text-secondary);
-            line-height: 1.5;
-        }
-
-        .login-prompt-text a {
-            color: var(--accent);
-            text-decoration: none;
-            font-weight: 600;
-        }
-
-        .login-prompt-text a:hover { text-decoration: underline; }
-
-        .server-message {
-            margin-top: 1.25rem;
-            padding: 0.875rem 1rem;
-            background: var(--bg-card-inner);
-            border: 1px solid var(--border);
-            border-left: 3px solid var(--error-color);
-            border-radius: 8px;
-            font-size: 13px;
-            color: var(--text-secondary);
-            text-align: left;
-            line-height: 1.6;
-        }
-
-        .server-message .msg-label {
-            font-size: 11px;
-            font-weight: 600;
-            letter-spacing: 1px;
-            text-transform: uppercase;
-            color: var(--text-muted);
-            margin-bottom: 4px;
-        }
-
-        .divider {
-            height: 1px;
-            background: var(--border);
-            margin: 2rem 0;
-        }
-
-        .btn-group {
-            display: flex;
-            gap: 12px;
-            justify-content: center;
-        }
-
-        .btn {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            padding: 0.65rem 1.4rem;
-            font-size: 14px;
-            font-weight: 600;
-            border-radius: 8px;
-            border: none;
-            cursor: pointer;
-            text-decoration: none;
-            transition: opacity 0.15s, background 0.15s;
-        }
-
-        .btn-primary {
-            background: var(--accent);
-            color: #0d1117;
-        }
-
-        .btn-primary:hover { opacity: 0.88; }
-
-        .btn-ghost {
-            background: transparent;
-            color: var(--text-secondary);
-            border: 1px solid var(--btn-ghost-border);
-        }
-
-        .btn-ghost:hover {
-            background: var(--btn-ghost-hover);
-            color: var(--text-primary);
-        }
-
-        @media (max-width: 480px) {
-            .btn-group { flex-direction: column; }
-            .btn { justify-content: center; }
-            .error-title { font-size: 22px; }
-        }
-    </style>
+    <title>403 - 접근 권한 없음</title>
+    <th:block layout:fragment="head-extra">
+        <th:block th:replace="~{fragments/error_page_head :: errorPageHead}"></th:block>
+    </th:block>
 </head>
-<body>
-
-<div class="container">
-
-    <a href="/" class="logo">
-        <div class="logo-mark">K</div>
-        <span class="logo-text">Knoc.</span>
-    </a>
-
-    <div class="error-card">
-
-        <div class="icon-wrap">
-            <i class="bi bi-shield-lock"></i>
-        </div>
-
-        <p class="error-code">Error 403</p>
-        <h1 class="error-title">접근 권한이 없어요</h1>
-        <p class="error-desc">
-            이 페이지를 볼 수 있는 권한이 없어요.<br>
-            로그인 후 다시 시도하거나, 권한을 확인해 주세요.
-        </p>
-
-        <!-- Login prompt -->
-        <div class="login-prompt">
-            <i class="bi bi-person-circle"></i>
-            <div class="login-prompt-text">
-                아직 로그인하지 않으셨나요?&nbsp;
-                <a href="/login">로그인하러 가기 →</a>
+<div layout:fragment="content">
+    <section class="container py-5 my-lg-4">
+        <div class="error-shell px-3">
+            <div class="card card-dark rounded-4 border-secondary text-center p-4 p-md-5">
+                <div class="error-icon-wrap error-icon-wrap--danger">
+                    <i class="bi bi-shield-lock" aria-hidden="true"></i>
+                </div>
+                <p class="error-code-label text-danger mb-2">Error 403</p>
+                <h1 class="h3 fw-bold text-white mb-3">접근 권한이 없어요</h1>
+                <p class="text-secondary mb-0">
+                    이 페이지를 볼 수 있는 권한이 없어요.<br>
+                    로그인 후 다시 시도하거나, 권한을 확인해 주세요.
+                </p>
+                <div class="d-flex align-items-start gap-3 text-start bg-dark bg-opacity-50 border border-secondary rounded-3 p-3 mt-4">
+                    <i class="bi bi-person-circle text-mint fs-4 flex-shrink-0" aria-hidden="true"></i>
+                    <p class="small text-secondary mb-0">
+                        아직 로그인하지 않으셨나요?
+                        <a class="text-mint fw-semibold text-decoration-none" th:href="@{/auth/login}">로그인하러 가기 →</a>
+                    </p>
+                </div>
+                <div class="alert alert-dark border border-secondary border-start border-danger border-3 text-start small mt-3 mb-0"
+                     th:if="${message != null and !#strings.isEmpty(message)}">
+                    <div class="text-uppercase text-muted fw-semibold mb-1" style="font-size: 0.7rem; letter-spacing: 0.08em;">상세 메시지</div>
+                    <span class="text-secondary" th:text="${message}"></span>
+                </div>
+                <hr class="border-secondary my-4">
+                <div class="d-flex flex-column flex-sm-row gap-2 justify-content-center">
+                    <a class="btn btn-mint rounded-3 px-4" th:href="@{/}">
+                        <i class="bi bi-house-fill me-1" aria-hidden="true"></i>메인으로 돌아가기
+                    </a>
+                    <button type="button" class="btn btn-outline-secondary error-ghost-btn rounded-3 px-4" onclick="history.back()">
+                        <i class="bi bi-arrow-left me-1" aria-hidden="true"></i>이전 페이지로
+                    </button>
+                </div>
             </div>
         </div>
-
-        <!-- Thymeleaf: server message (optional) -->
-        <div class="server-message" th:if="${message != null and !#strings.isEmpty(message)}">
-            <div class="msg-label">상세 메시지</div>
-            <span th:text="${message}"></span>
-        </div>
-
-        <div class="divider"></div>
-
-        <div class="btn-group">
-            <a href="/" class="btn btn-primary">
-                <i class="bi bi-house-fill" style="font-size:14px;"></i>
-                메인으로 돌아가기
-            </a>
-            <button onclick="history.back()" class="btn btn-ghost">
-                <i class="bi bi-arrow-left" style="font-size:14px;"></i>
-                이전 페이지로
-            </button>
-        </div>
-
-    </div>
-
+    </section>
 </div>
-
-</body>
 </html>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,307 +1,69 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/default_layout}">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>404 - 페이지를 찾을 수 없음 | Knoc</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <style>
-        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-        :root {
-            --bg-primary: #0d1117;
-            --bg-card: #161b22;
-            --bg-card-inner: #1c2128;
-            --border: rgba(48, 54, 61, 0.8);
-            --text-primary: #e6edf3;
-            --text-secondary: #8b949e;
-            --text-muted: #6e7681;
-            --accent: #00c8c8;
-            --accent-dim: rgba(0, 200, 200, 0.10);
-            --accent-border: rgba(0, 200, 200, 0.3);
-            --btn-ghost-border: rgba(139, 148, 158, 0.3);
-            --btn-ghost-hover: rgba(139, 148, 158, 0.08);
-        }
-
-        body {
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans KR', sans-serif;
-            min-height: 100vh;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            padding: 2rem 1.5rem;
-        }
-
-        body::before {
-            content: '';
-            position: fixed;
-            inset: 0;
-            background-image:
-                linear-gradient(rgba(0,200,200,0.03) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(0,200,200,0.03) 1px, transparent 1px);
-            background-size: 60px 60px;
-            pointer-events: none;
-            z-index: 0;
-        }
-
-        .container {
-            position: relative;
-            z-index: 1;
-            width: 100%;
-            max-width: 560px;
-            text-align: center;
-        }
-
-        .logo {
-            display: inline-flex;
-            align-items: center;
-            gap: 10px;
-            margin-bottom: 3rem;
-            text-decoration: none;
-        }
-
-        .logo-mark {
-            width: 36px;
-            height: 36px;
-            background: var(--accent);
-            border-radius: 8px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-weight: 700;
-            font-size: 15px;
-            color: #0d1117;
-            letter-spacing: -0.5px;
-        }
-
-        .logo-text {
-            font-size: 20px;
-            font-weight: 700;
-            color: var(--text-primary);
-            letter-spacing: -0.5px;
-        }
-
-        .error-card {
-            background: var(--bg-card);
-            border: 1px solid var(--border);
-            border-radius: 16px;
-            padding: 2.5rem 2rem;
-        }
-
-        /* Big 404 display */
-        .error-display {
-            margin-bottom: 1.5rem;
-        }
-
-        .error-number {
-            font-size: 88px;
-            font-weight: 800;
-            line-height: 1;
-            letter-spacing: -4px;
-            background: linear-gradient(135deg, var(--accent) 0%, rgba(0,200,200,0.4) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-
-        .icon-under {
-            margin-top: 0.5rem;
-            font-size: 28px;
-            color: var(--text-muted);
-        }
-
-        .error-title {
-            font-size: 24px;
-            font-weight: 700;
-            color: var(--text-primary);
-            line-height: 1.3;
-            margin-bottom: 1rem;
-        }
-
-        .error-desc {
-            font-size: 15px;
-            color: var(--text-secondary);
-            line-height: 1.7;
-        }
-
-        /* Quick links */
-        .quick-links {
-            margin-top: 1.5rem;
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 10px;
-        }
-
-        .quick-link {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-            padding: 0.75rem 1rem;
-            background: var(--bg-card-inner);
-            border: 1px solid var(--border);
-            border-radius: 10px;
-            text-decoration: none;
-            color: var(--text-secondary);
-            font-size: 13px;
-            font-weight: 500;
-            transition: border-color 0.15s, color 0.15s;
-            text-align: left;
-        }
-
-        .quick-link:hover {
-            border-color: var(--accent-border);
-            color: var(--text-primary);
-        }
-
-        .quick-link i {
-            font-size: 16px;
-            color: var(--accent);
-            flex-shrink: 0;
-        }
-
-        .server-message {
-            margin-top: 1.25rem;
-            padding: 0.875rem 1rem;
-            background: var(--bg-card-inner);
-            border: 1px solid var(--border);
-            border-left: 3px solid var(--accent);
-            border-radius: 8px;
-            font-size: 13px;
-            color: var(--text-secondary);
-            text-align: left;
-            line-height: 1.6;
-        }
-
-        .server-message .msg-label {
-            font-size: 11px;
-            font-weight: 600;
-            letter-spacing: 1px;
-            text-transform: uppercase;
-            color: var(--text-muted);
-            margin-bottom: 4px;
-        }
-
-        .divider {
-            height: 1px;
-            background: var(--border);
-            margin: 2rem 0;
-        }
-
-        .btn-group {
-            display: flex;
-            gap: 12px;
-            justify-content: center;
-        }
-
-        .btn {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            padding: 0.65rem 1.4rem;
-            font-size: 14px;
-            font-weight: 600;
-            border-radius: 8px;
-            border: none;
-            cursor: pointer;
-            text-decoration: none;
-            transition: opacity 0.15s, background 0.15s;
-        }
-
-        .btn-primary {
-            background: var(--accent);
-            color: #0d1117;
-        }
-
-        .btn-primary:hover { opacity: 0.88; }
-
-        .btn-ghost {
-            background: transparent;
-            color: var(--text-secondary);
-            border: 1px solid var(--btn-ghost-border);
-        }
-
-        .btn-ghost:hover {
-            background: var(--btn-ghost-hover);
-            color: var(--text-primary);
-        }
-
-        @media (max-width: 480px) {
-            .error-number { font-size: 64px; }
-            .quick-links { grid-template-columns: 1fr; }
-            .btn-group { flex-direction: column; }
-            .btn { justify-content: center; }
-        }
-    </style>
+    <title>404 - 페이지를 찾을 수 없음</title>
+    <th:block layout:fragment="head-extra">
+        <th:block th:replace="~{fragments/error_page_head :: errorPageHead}"></th:block>
+    </th:block>
 </head>
-<body>
-
-<div class="container">
-
-    <a href="/" class="logo">
-        <div class="logo-mark">K</div>
-        <span class="logo-text">Knoc.</span>
-    </a>
-
-    <div class="error-card">
-
-        <div class="error-display">
-            <div class="error-number">404</div>
-            <div class="icon-under">
-                <i class="bi bi-map"></i>
+<div layout:fragment="content">
+    <section class="container py-5 my-lg-4">
+        <div class="error-shell px-3">
+            <div class="card card-dark rounded-4 border-secondary text-center p-4 p-md-5">
+                <div class="error-number-404 mb-2">404</div>
+                <div class="text-secondary mb-4"><i class="bi bi-map" aria-hidden="true"></i></div>
+                <h1 class="h4 fw-bold text-white mb-3">페이지를 찾을 수 없어요</h1>
+                <p class="text-secondary mb-0">
+                    주소가 잘못되었거나, 이미 사라진 페이지예요.<br>
+                    URL을 다시 확인하거나 아래 링크를 이용해 보세요.
+                </p>
+                <div class="row g-2 mt-4 text-start small">
+                    <div class="col-sm-6">
+                        <a class="d-flex align-items-center gap-2 text-decoration-none text-secondary bg-dark bg-opacity-50 border border-secondary rounded-3 p-3 h-100"
+                           th:href="@{/seniors}">
+                            <i class="bi bi-people text-mint" aria-hidden="true"></i>
+                            <span>시니어 매칭</span>
+                        </a>
+                    </div>
+                    <div class="col-sm-6">
+                        <a class="d-flex align-items-center gap-2 text-decoration-none text-secondary bg-dark bg-opacity-50 border border-secondary rounded-3 p-3 h-100"
+                           th:href="@{/my/mentoring}">
+                            <i class="bi bi-chat-quote text-mint" aria-hidden="true"></i>
+                            <span>멘토링 내역</span>
+                        </a>
+                    </div>
+                    <div class="col-sm-6">
+                        <a class="d-flex align-items-center gap-2 text-decoration-none text-secondary bg-dark bg-opacity-50 border border-secondary rounded-3 p-3 h-100"
+                           th:href="@{/senior/apply}">
+                            <i class="bi bi-person-badge text-mint" aria-hidden="true"></i>
+                            <span>시니어 지원하기</span>
+                        </a>
+                    </div>
+                    <div class="col-sm-6">
+                        <a class="d-flex align-items-center gap-2 text-decoration-none text-secondary bg-dark bg-opacity-50 border border-secondary rounded-3 p-3 h-100"
+                           th:href="@{/auth/login}">
+                            <i class="bi bi-box-arrow-in-right text-mint" aria-hidden="true"></i>
+                            <span>로그인</span>
+                        </a>
+                    </div>
+                </div>
+                <div class="alert alert-dark border border-secondary border-start border-3 text-start small mt-3 mb-0"
+                     style="border-left-color: #00CFE8 !important;"
+                     th:if="${message != null and !#strings.isEmpty(message)}">
+                    <div class="text-uppercase text-muted fw-semibold mb-1" style="font-size: 0.7rem; letter-spacing: 0.08em;">상세 메시지</div>
+                    <span class="text-secondary" th:text="${message}"></span>
+                </div>
+                <hr class="border-secondary my-4">
+                <div class="d-flex flex-column flex-sm-row gap-2 justify-content-center">
+                    <a class="btn btn-mint rounded-3 px-4" th:href="@{/}">
+                        <i class="bi bi-house-fill me-1" aria-hidden="true"></i>메인으로 돌아가기
+                    </a>
+                    <button type="button" class="btn btn-outline-secondary error-ghost-btn rounded-3 px-4" onclick="history.back()">
+                        <i class="bi bi-arrow-left me-1" aria-hidden="true"></i>이전 페이지로
+                    </button>
+                </div>
             </div>
         </div>
-
-        <h1 class="error-title">페이지를 찾을 수 없어요</h1>
-        <p class="error-desc">
-            주소가 잘못되었거나, 이미 사라진 페이지예요.<br>
-            URL을 다시 확인하거나 아래 링크를 이용해 보세요.
-        </p>
-
-        <!-- Quick navigation links -->
-        <div class="quick-links">
-            <a href="/senior-matching" class="quick-link">
-                <i class="bi bi-people"></i>
-                시니어 매칭
-            </a>
-            <a href="/mentoring-reviews" class="quick-link">
-                <i class="bi bi-chat-quote"></i>
-                멘토링 후기
-            </a>
-            <a href="/senior-apply" class="quick-link">
-                <i class="bi bi-person-badge"></i>
-                시니어 지원하기
-            </a>
-            <a href="/login" class="quick-link">
-                <i class="bi bi-box-arrow-in-right"></i>
-                로그인
-            </a>
-        </div>
-
-        <!-- Thymeleaf: server message (optional) -->
-        <div class="server-message" th:if="${message != null and !#strings.isEmpty(message)}">
-            <div class="msg-label">상세 메시지</div>
-            <span th:text="${message}"></span>
-        </div>
-
-        <div class="divider"></div>
-
-        <div class="btn-group">
-            <a href="/" class="btn btn-primary">
-                <i class="bi bi-house-fill" style="font-size:14px;"></i>
-                메인으로 돌아가기
-            </a>
-            <button onclick="history.back()" class="btn btn-ghost">
-                <i class="bi bi-arrow-left" style="font-size:14px;"></i>
-                이전 페이지로
-            </button>
-        </div>
-
-    </div>
-
+    </section>
 </div>
-
-</body>
 </html>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -1,340 +1,61 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/default_layout}">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>500 - 서버 오류 | Knoc</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <style>
-        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-        :root {
-            --bg-primary: #0d1117;
-            --bg-card: #161b22;
-            --bg-card-inner: #1c2128;
-            --border: rgba(48, 54, 61, 0.8);
-            --text-primary: #e6edf3;
-            --text-secondary: #8b949e;
-            --text-muted: #6e7681;
-            --accent: #00c8c8;
-            --error-color: #9d7ae8;
-            --error-dim: rgba(157, 122, 232, 0.12);
-            --error-border: rgba(157, 122, 232, 0.35);
-            --btn-ghost-border: rgba(139, 148, 158, 0.3);
-            --btn-ghost-hover: rgba(139, 148, 158, 0.08);
-        }
-
-        body {
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans KR', sans-serif;
-            min-height: 100vh;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            padding: 2rem 1.5rem;
-        }
-
-        body::before {
-            content: '';
-            position: fixed;
-            inset: 0;
-            background-image:
-                linear-gradient(rgba(0,200,200,0.03) 1px, transparent 1px),
-                linear-gradient(90deg, rgba(0,200,200,0.03) 1px, transparent 1px);
-            background-size: 60px 60px;
-            pointer-events: none;
-            z-index: 0;
-        }
-
-        .container {
-            position: relative;
-            z-index: 1;
-            width: 100%;
-            max-width: 560px;
-            text-align: center;
-        }
-
-        .logo {
-            display: inline-flex;
-            align-items: center;
-            gap: 10px;
-            margin-bottom: 3rem;
-            text-decoration: none;
-        }
-
-        .logo-mark {
-            width: 36px;
-            height: 36px;
-            background: var(--accent);
-            border-radius: 8px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-weight: 700;
-            font-size: 15px;
-            color: #0d1117;
-            letter-spacing: -0.5px;
-        }
-
-        .logo-text {
-            font-size: 20px;
-            font-weight: 700;
-            color: var(--text-primary);
-            letter-spacing: -0.5px;
-        }
-
-        .error-card {
-            background: var(--bg-card);
-            border: 1px solid var(--border);
-            border-radius: 16px;
-            padding: 2.5rem 2rem;
-        }
-
-        .icon-wrap {
-            width: 80px;
-            height: 80px;
-            margin: 0 auto 1.5rem;
-            background: var(--error-dim);
-            border: 1px solid var(--error-border);
-            border-radius: 20px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .icon-wrap i {
-            font-size: 36px;
-            color: var(--error-color);
-        }
-
-        .error-code {
-            font-size: 13px;
-            font-weight: 600;
-            letter-spacing: 2px;
-            text-transform: uppercase;
-            color: var(--error-color);
-            margin-bottom: 0.75rem;
-        }
-
-        .error-title {
-            font-size: 26px;
-            font-weight: 700;
-            color: var(--text-primary);
-            line-height: 1.3;
-            margin-bottom: 1rem;
-        }
-
-        .error-desc {
-            font-size: 15px;
-            color: var(--text-secondary);
-            line-height: 1.7;
-        }
-
-        /* Status checklist */
-        .status-box {
-            margin-top: 1.5rem;
-            padding: 1rem 1.25rem;
-            background: var(--bg-card-inner);
-            border: 1px solid var(--border);
-            border-radius: 10px;
-            text-align: left;
-        }
-
-        .status-box-title {
-            font-size: 12px;
-            font-weight: 600;
-            letter-spacing: 1px;
-            text-transform: uppercase;
-            color: var(--text-muted);
-            margin-bottom: 0.75rem;
-        }
-
-        .status-item {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-            padding: 6px 0;
-            font-size: 13px;
-            color: var(--text-secondary);
-        }
-
-        .status-item + .status-item {
-            border-top: 1px solid rgba(48, 54, 61, 0.5);
-        }
-
-        .status-dot {
-            width: 8px;
-            height: 8px;
-            border-radius: 50%;
-            flex-shrink: 0;
-        }
-
-        .dot-ok { background: #3fb950; }
-        .dot-warn { background: #e8a838; }
-        .dot-err { background: #e05c5c; }
-
-        /* Countdown retry */
-        .retry-hint {
-            margin-top: 1.25rem;
-            padding: 0.75rem 1rem;
-            background: var(--error-dim);
-            border: 1px solid var(--error-border);
-            border-radius: 8px;
-            font-size: 13px;
-            color: var(--text-secondary);
-            display: flex;
-            align-items: center;
-            gap: 8px;
-        }
-
-        .retry-hint i {
-            color: var(--error-color);
-            font-size: 15px;
-            flex-shrink: 0;
-        }
-
-        .server-message {
-            margin-top: 1.25rem;
-            padding: 0.875rem 1rem;
-            background: var(--bg-card-inner);
-            border: 1px solid var(--border);
-            border-left: 3px solid var(--error-color);
-            border-radius: 8px;
-            font-size: 13px;
-            color: var(--text-secondary);
-            text-align: left;
-            line-height: 1.6;
-        }
-
-        .server-message .msg-label {
-            font-size: 11px;
-            font-weight: 600;
-            letter-spacing: 1px;
-            text-transform: uppercase;
-            color: var(--text-muted);
-            margin-bottom: 4px;
-        }
-
-        .divider {
-            height: 1px;
-            background: var(--border);
-            margin: 2rem 0;
-        }
-
-        .btn-group {
-            display: flex;
-            gap: 12px;
-            justify-content: center;
-        }
-
-        .btn {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            padding: 0.65rem 1.4rem;
-            font-size: 14px;
-            font-weight: 600;
-            border-radius: 8px;
-            border: none;
-            cursor: pointer;
-            text-decoration: none;
-            transition: opacity 0.15s, background 0.15s;
-        }
-
-        .btn-primary {
-            background: var(--accent);
-            color: #0d1117;
-        }
-
-        .btn-primary:hover { opacity: 0.88; }
-
-        .btn-ghost {
-            background: transparent;
-            color: var(--text-secondary);
-            border: 1px solid var(--btn-ghost-border);
-        }
-
-        .btn-ghost:hover {
-            background: var(--btn-ghost-hover);
-            color: var(--text-primary);
-        }
-
-        @media (max-width: 480px) {
-            .btn-group { flex-direction: column; }
-            .btn { justify-content: center; }
-            .error-title { font-size: 22px; }
-        }
-    </style>
+    <title>500 - 서버 오류</title>
+    <th:block layout:fragment="head-extra">
+        <th:block th:replace="~{fragments/error_page_head :: errorPageHead}"></th:block>
+    </th:block>
 </head>
-<body>
-
-<div class="container">
-
-    <a href="/" class="logo">
-        <div class="logo-mark">K</div>
-        <span class="logo-text">Knoc.</span>
-    </a>
-
-    <div class="error-card">
-
-        <div class="icon-wrap">
-            <i class="bi bi-gear"></i>
-        </div>
-
-        <p class="error-code">Error 500</p>
-        <h1 class="error-title">안정적인 서비스 제공을 위해 점검 중입니다</h1>
-        <p class="error-desc">
-            현재 시스템 최적화 및 서버 안정화 작업을 진행하고 있습니다.<br>
-            더욱 쾌적한 Knoc를 만들기 위한 과정이오니 잠시만 기다려 주세요.
-        </p>
-
-        <!-- Status indicators -->
-        <div class="status-box">
-            <div class="status-box-title">서비스 상태</div>
-            <div class="status-item">
-                <span class="status-dot dot-ok"></span>
-                DB 연결 상태 : 원활
+<div layout:fragment="content">
+    <section class="container py-5 my-lg-4">
+        <div class="error-shell px-3">
+            <div class="card card-dark rounded-4 border-secondary text-center p-4 p-md-5">
+                <div class="error-icon-wrap error-icon-wrap--violet">
+                    <i class="bi bi-gear" aria-hidden="true"></i>
+                </div>
+                <p class="error-code-label mb-2" style="color: #9d7ae8;">Error 500</p>
+                <h1 class="h3 fw-bold text-white mb-3">안정적인 서비스 제공을 위해 점검 중입니다</h1>
+                <p class="text-secondary mb-0">
+                    현재 시스템 최적화 및 서버 안정화 작업을 진행하고 있습니다.<br>
+                    더욱 쾌적한 Knoc를 만들기 위한 과정이오니 잠시만 기다려 주세요.
+                </p>
+                <div class="text-start bg-dark bg-opacity-50 border border-secondary rounded-3 p-3 mt-4">
+                    <div class="text-uppercase text-muted fw-semibold mb-2" style="font-size: 0.7rem; letter-spacing: 0.08em;">서비스 상태</div>
+                    <div class="d-flex align-items-center gap-2 py-2 border-bottom border-secondary border-opacity-50 small text-secondary">
+                        <span class="rounded-circle flex-shrink-0" style="width: 8px; height: 8px; background: #3fb950;"></span>
+                        DB 연결 상태 : 원활
+                    </div>
+                    <div class="d-flex align-items-center gap-2 py-2 border-bottom border-secondary border-opacity-50 small text-secondary">
+                        <span class="rounded-circle flex-shrink-0" style="width: 8px; height: 8px; background: #e8a838;"></span>
+                        시스템 업데이트 : 진행 중
+                    </div>
+                    <div class="d-flex align-items-center gap-2 pt-2 small text-secondary">
+                        <span class="rounded-circle flex-shrink-0" style="width: 8px; height: 8px; background: #3fb950;"></span>
+                        정적 리소스 : 원활
+                    </div>
+                </div>
+                <div class="d-flex align-items-start gap-2 text-start small text-secondary border rounded-3 p-3 mt-3"
+                     style="background: rgba(157, 122, 232, 0.08); border-color: rgba(157, 122, 232, 0.35) !important;">
+                    <i class="bi bi-arrow-clockwise flex-shrink-0" style="color: #9d7ae8;" aria-hidden="true"></i>
+                    <span>작업이 완료되면 자동으로 서비스가 재개됩니다.</span>
+                </div>
+                <div class="alert alert-dark border border-secondary border-start border-3 text-start small mt-3 mb-0"
+                     style="border-left-color: #9d7ae8 !important;"
+                     th:if="${message != null and !#strings.isEmpty(message)}">
+                    <div class="text-uppercase text-muted fw-semibold mb-1" style="font-size: 0.7rem; letter-spacing: 0.08em;">상세 메시지</div>
+                    <span class="text-secondary" th:text="${message}"></span>
+                </div>
+                <hr class="border-secondary my-4">
+                <div class="d-flex flex-column flex-sm-row gap-2 justify-content-center">
+                    <a class="btn btn-mint rounded-3 px-4" th:href="@{/}">
+                        <i class="bi bi-house-fill me-1" aria-hidden="true"></i>메인으로 돌아가기
+                    </a>
+                    <button type="button" class="btn btn-outline-secondary error-ghost-btn rounded-3 px-4" onclick="history.back()">
+                        <i class="bi bi-arrow-left me-1" aria-hidden="true"></i>이전 페이지로
+                    </button>
+                </div>
             </div>
-            <div class="status-item">
-                <span class="status-dot dot-warn"></span>
-                시스템 업데이트 : 진행 중
-            </div>
-            <div class="status-item">
-                <span class="status-dot dot-ok"></span>
-                정적 리소스 : 원활
-            </div>
         </div>
-
-        <!-- Retry suggestion -->
-        <div class="retry-hint">
-            <i class="bi bi-arrow-clockwise"></i>
-            작업이 완료되면 자동으로 서비스가 재개됩니다.
-        </div>
-
-        <!-- Thymeleaf: server message (optional) -->
-        <div class="server-message" th:if="${message != null and !#strings.isEmpty(message)}">
-            <div class="msg-label">상세 메시지</div>
-            <span th:text="${message}"></span>
-        </div>
-
-        <div class="divider"></div>
-
-        <div class="btn-group">
-            <a href="/" class="btn btn-primary">
-                <i class="bi bi-house-fill" style="font-size:14px;"></i>
-                메인으로 돌아가기
-            </a>
-            <button onclick="history.back()" class="btn btn-ghost">
-                <i class="bi bi-arrow-left" style="font-size:14px;"></i>
-                이전 페이지로
-            </button>
-        </div>
-
-    </div>
-
+    </section>
 </div>
-
-</body>
 </html>

--- a/src/main/resources/templates/fragments/error_page_head.html
+++ b/src/main/resources/templates/fragments/error_page_head.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<th:block th:fragment="errorPageHead">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <style>
+        .error-shell {
+            max-width: 36rem;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .error-icon-wrap {
+            width: 80px;
+            height: 80px;
+            margin: 0 auto 1.5rem;
+            border-radius: 1.25rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 2.25rem;
+        }
+
+        .error-icon-wrap--amber {
+            background: rgba(232, 168, 56, 0.12);
+            border: 1px solid rgba(232, 168, 56, 0.35);
+            color: #e8a838;
+        }
+
+        .error-icon-wrap--danger {
+            background: rgba(224, 92, 92, 0.12);
+            border: 1px solid rgba(224, 92, 92, 0.35);
+            color: #e05c5c;
+        }
+
+        .error-icon-wrap--mint {
+            background: rgba(0, 207, 232, 0.12);
+            border: 1px solid rgba(0, 207, 232, 0.35);
+            color: #00CFE8;
+        }
+
+        .error-icon-wrap--violet {
+            background: rgba(157, 122, 232, 0.12);
+            border: 1px solid rgba(157, 122, 232, 0.35);
+            color: #9d7ae8;
+        }
+
+        .error-code-label {
+            font-size: 0.8125rem;
+            font-weight: 600;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            margin-bottom: 0.5rem;
+        }
+
+        .error-ghost-btn {
+            color: #adb5bd;
+            border-color: rgba(255, 255, 255, 0.2);
+        }
+
+        .error-ghost-btn:hover {
+            color: #fff;
+            background-color: rgba(255, 255, 255, 0.06);
+            border-color: rgba(255, 255, 255, 0.25);
+        }
+
+        .error-number-404 {
+            font-size: clamp(3.5rem, 12vw, 5.5rem);
+            font-weight: 800;
+            line-height: 1;
+            letter-spacing: -0.06em;
+            color: #00CFE8;
+        }
+    </style>
+</th:block>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout/default_layout}">
+<head>
+    <title>Knoc. 완벽한 사수를 만나는 가장 가벼운 노크</title>
+</head>
 
 <div layout:fragment="content">
 

--- a/src/main/resources/templates/layout/default_layout.html
+++ b/src/main/resources/templates/layout/default_layout.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Knoc. 완벽한 사수를 만나는 가장 가벼운 노크</title>
+    <title layout:title-pattern="$CONTENT_TITLE">Knoc.</title>
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 
@@ -44,6 +44,7 @@
             box-shadow: 0 0 0 0.25rem rgba(0, 207, 232, 0.25);
         }
     </style>
+    <th:block layout:fragment="head-extra"></th:block>
 </head>
 <body>
 <th:block th:replace="~{fragments/header :: headerFragment}"></th:block>


### PR DESCRIPTION
## 🔎 What

- 에러 페이지(400/403/404/500)를 default_layout 기반으로 전환해 헤더/푸터 포함 전반 UI를 통일
- 레이아웃 <head>에 head-extra 확장 슬롯을 추가해 페이지별 리소스를 필요할 때만 주입 가능하게 구성
- 에러 페이지 전용 head 리소스(bootstrap-icons, 최소 CSS)를 error_page_head fragment로 공통화
- 에러 페이지 스타일을 프로젝트 테마(card-dark, btn-mint, text-mint)에 맞게 정리
- 에러 페이지 내부 링크를 프로젝트 라우팅에 맞게 정리(@{/seniors}, @{/my/mentoring}, @{/senior/apply}, @{/auth/login})
- 타이틀 정책을 정리(layout:title-pattern은 $CONTENT_TITLE, 홈은 index.html에서 <title> 유지)

## 500 에러 화면
<img width="1483" height="1500" alt="localhost_8080_aaaa (1)" src="https://github.com/user-attachments/assets/f16a7aed-2251-4110-a8f1-82f33cb7db5d" />

이렇게 에러 페이지에도 헤더, 푸터가 노출됩니다.

## 🔗 Issue

- Closes: #15 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?

