### PR TITLE
fix: 상태에 맞는 에러 페이지가 안 뜨는 오류 해결

### DIFF
--- a/src/main/java/com/knoc/global/config/CustomErrorController.java
+++ b/src/main/java/com/knoc/global/config/CustomErrorController.java
@@ -1,11 +1,15 @@
 package com.knoc.global.config;
 
+import com.knoc.global.exception.ErrorCode;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
 
 // [전역 에러 컨트롤러]
 // - 스프링의 컨트롤러에 도달하기 전이나, 스프링 밖(서블릿 컨테이너 레벨)에서 발생하는 에러를 처리합니다.
@@ -14,21 +18,34 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 public class CustomErrorController implements ErrorController {
-    // 스프링 부트 에러 기본 경로인 /error로 들어오는 요청 처리
+
     @RequestMapping("/error")
-    public String handleError(HttpServletRequest request) {
+    public Object handleError(HttpServletRequest request) {
         // HTTP 상태 코드를 요청 객체에서 꺼내옴
         Object status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        String accept = request.getHeader("accept");
 
         if  (status != null) {
             int statusCode = Integer.parseInt(status.toString());
 
-            // 상태 코드에 따른 페이지 분기
+            // ErrorCode Enum에서 적절한 에러 정보 추출
+            String message = ErrorCode.INTERNAL_SERVER_ERROR.getMessage();
+            if (statusCode == HttpStatus.NOT_FOUND.value()) message = ErrorCode.ENTITY_NOT_FOUND.getMessage();
+            else if (statusCode == HttpStatus.FORBIDDEN.value()) message = ErrorCode.ACCESS_DENIED.getMessage();
+            else if (statusCode == HttpStatus.BAD_REQUEST.value()) message = ErrorCode.INVALID_INPUT_VALUE.getMessage();
+
+            // 1. AJAX(JSON) 요청인 경우: ErrorCode 기반 메시지로 응답
+            if (accept != null && accept.contains("application/json")) {
+                return ResponseEntity.status(statusCode)
+                        .body(Map.of("status", statusCode, "message", message));
+            }
+
+            // 2. 일반 페이지(HTML) 요청인 경우: 상태 코드별 HTML 페이지 반환
             if (statusCode == HttpStatus.NOT_FOUND.value()) return "error/404";
             if (statusCode == HttpStatus.FORBIDDEN.value()) return "error/403";
             if (statusCode == HttpStatus.BAD_REQUEST.value()) return "error/400";
         }
-        // 위 3가지 경우 외의 모든 에러는 기본적으로 500 페이지 보여줌
+        // 그 외의 모든 에러는 기본 500 페이지 보여줌
         return "error/500";
     }
 }

--- a/src/main/java/com/knoc/global/config/SecurityConfig.java
+++ b/src/main/java/com/knoc/global/config/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // url 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
-                        // auth로 시작하는 모든 url 인증 없이 접근 허용(정적 리소스 추가)
+                        // auth, error로 시작하는 모든 url 인증 없이 접근 허용(정적 리소스 추가)
                         .requestMatchers("/auth/**", "/error/**", "/css/**", "/js/**", "/images/**").permitAll()
                         // 그외 나머지 경로는 인증을 해야만 접근 허용
                         .anyRequest().authenticated()

--- a/src/main/java/com/knoc/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/knoc/global/exception/GlobalExceptionHandler.java
@@ -1,61 +1,67 @@
 package com.knoc.global.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
-import java.util.HashMap;
 import java.util.Map;
 
 // [비즈니스 로직 예외 처리기]
 // - 컨트롤러 내부에서 발생하여 밖으로 던져진 예외를 가로채는 역할을 합니다.
 // - 특정 비즈니스 상황(예: 잔액 부족, 중복 가입 등)에서 우리가 직접 throw한 예외를 처리합니다.
 // - 상세한 에러 메시지를 Model에 담아 뷰(HTML)에 전달할 수 있다는 장점이 있습니다.
+// - 예외 발생 시 로그를 남기도록 개선했습니다.
 
+@Slf4j // 로그를 찍기 위해 추가 (private statis final Logger log...와 같음)
 @ControllerAdvice // // 모든 컨트롤러에서 발생하는 예외를 감시하겠다고 선언
 public class GlobalExceptionHandler {
 
     // 프로젝트에서 정의한 BusinessException이 발생했을 때 호출됨
     @ExceptionHandler(BusinessException.class)
     public Object handleBusinessException(BusinessException e, HttpServletRequest request, Model model) {
-        String accept = request.getHeader("Accept");
+        // 비즈니스 예외는 의도된 에러이므로 경고(warn) 수준으로 로그 기록
+        log.warn("Business Exception: {}", e.getMessage());
 
+        String accept = request.getHeader("Accept");
+        ErrorCode errorCode = e.getErrorCode();
         // 1. API(AJAX) 요청일 경우 (Accept 헤더에 application/json이 포함된 경우)
         if (accept != null && accept.contains("application/json")) {
-            // [AJAX 응답] 브라우저 콘솔이나 자바스크립트에 에러 정보를 JSON으로 전달
-            ErrorCode errorCode = e.getErrorCode();
-            Map<String, Object> body = new HashMap<>();
-            body.put("message", errorCode.getMessage());
-            body.put("status", errorCode.getStatus());
-
-            return ResponseEntity.status(errorCode.getStatus()).body(body);
+            // 브라우저 콘솔이나 자바스크립트에 에러 정보를 JSON으로 전달
+            return ResponseEntity.status(errorCode.getStatus())
+                    .body(Map.of("message", errorCode.getMessage(), "status", errorCode.getStatus()));
         }
 
         // 2. 일반 페이지 요청인 경우
-        // [일반 페이지 응답] 브라우저 화면 자체를 에러 페이지(HTML)로 이동시킴
         model.addAttribute("message", e.getMessage());
-        int status = e.getErrorCode().getStatus();
-        model.addAttribute("status", status);
-
+        model.addAttribute("status", errorCode.getStatus());
         // 에러 코드에 따라 적절한 페이지로 이동
-        return "error/" + status; // templates/error/400.html 등으로 매핑
+        return "error/" + errorCode.getStatus(); // templates/error/400.html 등으로 매핑
     }
 
-    // 위에서 처리하지 못한 그 외 모든 예외(500 에러) 처리
+    // [서버 오류 로깅 및 처리]
+    // - 위에서 처리하지 못한 그 외 모든 예외(NullPointer 등)를 처리합니다.
+    // - 404 에러는 CustomErrorController가 담당하도록 다시 던지며, 500 에러는 상세 로그를 남깁니다.
     @ExceptionHandler(Exception.class)
-    public Object handleException(Exception e, HttpServletRequest request) {
-        String accept = request.getHeader("Accept");
+    public Object handleAllException(Exception e, HttpServletRequest request) throws Exception {
 
-        // AJAX 요청인 경우 JSON으로 500 에러 응답
+        // 400, 403, 404 등 '스프링 표준 예외(ResponseStatusException 등)'는
+        // 직접 처리하지 않고 다시 던져서 CustomErrorController에게 양보합니다.
+        if (e instanceof NoResourceFoundException ||
+            e instanceof org.springframework.web.server.ResponseStatusException) {
+            throw e;
+        }
+
+        // 그 외의 예상치 못한 서버 에러는 에러(error) 수준 로그 찍고 500 처리
+        log.error("Unexpected Server Error: ", e);
+
+        String accept = request.getHeader("Accept");
         if (accept != null && accept.contains("application/json")) {
-            Map<String, Object> body = new HashMap<>();
-            body.put("message", "서버 내부 오류가 발생했습니다.");
-            body.put("status", 500);
-            return ResponseEntity
-                    .status(500)
-                    .body(body);
+            return ResponseEntity.status(500)
+                    .body(Map.of("message", ErrorCode.INTERNAL_SERVER_ERROR.getMessage(), "status", 500));
         }
 
         return "error/500";


### PR DESCRIPTION
## 🔎 What

- 상태 코드별 에러 페이지가 제대로 매핑되지 않는 오류를 개선했다.

## 🔗 Issue

- Closes: #38 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?

