### PR TITLE
[feat] 주문 결제(pay) API 뼈대 구현

### DIFF
--- a/src/main/java/com/knoc/chat/entity/MessageType.java
+++ b/src/main/java/com/knoc/chat/entity/MessageType.java
@@ -1,8 +1,8 @@
 package com.knoc.chat.entity;
 
 public enum MessageType {
-    USER,          // 일반 채팅
-    SYSTEM,        // 단순 알림 (예: "채팅방이 생성되었습니다. 시니어에게 인사를 건네보세요!"),
+    USER,              // 일반 채팅
+    SYSTEM,            // 단순 알림 (예: "채팅방이 생성되었습니다. 시니어에게 인사를 건네보세요!"),
     PAYMENT_REQUESTED, // 시니어가 결제를 요청함 (결제 버튼 노출)
     PAYMENT_COMPLETED, // 결제 완료됨 (주니어에게 "상세 리뷰 요청서 작성" 버튼 노출)
 }

--- a/src/main/java/com/knoc/global/exception/ErrorCode.java
+++ b/src/main/java/com/knoc/global/exception/ErrorCode.java
@@ -22,6 +22,9 @@ public enum ErrorCode {
     // 주문 관련 (Order)
     ORDER_NOT_FOUND(404, "존재하지 않는 주문입니다."),
     NOT_SENIOR_IN_ROOM(403, "해당 채팅방의 시니어가 아닙니다."), // 권한 검증용
+    NOT_JUNIOR_FOR_ORDER(403, "해당 주문의 주니어가 아닙니다."), // 권한 검증용
+    ORDER_CANNOT_BE_PAID(400, "현재 주문 상태에서는 결제를 진행할 수 없습니다."),
+    ORDER_PAYMENT_CONFLICT(409, "동시에 결제가 시도되어 처리에 실패했습니다. 다시 시도해주세요."),
 
     // 이메일 관련 (Auth)
     ALREADY_VERIFIED(400, "이미 완료된 인증입니다."),
@@ -29,7 +32,6 @@ public enum ErrorCode {
     INVALID_VERIFICATION_CODE(400, "인증번호가 일치하지 않습니다."),
     INVALID_EMAIL_DOMAIN(400, "기업 이메일만 인증 가능합니다."),
     EMAIL_VERIFICATION_NOT_FOUND(404, "인증 요청 내역이 없습니다.");
-
 
     private final int status;
     private final String message;

--- a/src/main/java/com/knoc/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/knoc/global/exception/GlobalExceptionHandler.java
@@ -44,7 +44,6 @@ public class GlobalExceptionHandler {
 
     // [서버 오류 로깅 및 처리]
     // - 위에서 처리하지 못한 그 외 모든 예외(NullPointer 등)를 처리합니다.
-    // - 404 에러는 CustomErrorController가 담당하도록 다시 던지며, 500 에러는 상세 로그를 남깁니다.
     @ExceptionHandler(Exception.class)
     public Object handleAllException(Exception e, HttpServletRequest request) throws Exception {
 

--- a/src/main/java/com/knoc/order/controller/OrderController.java
+++ b/src/main/java/com/knoc/order/controller/OrderController.java
@@ -26,4 +26,11 @@ public class OrderController {
         // 3. 생성된 주문 정보(JSON 데이터로 변환됨)와 함께 200 OK 응답을 브라우저로 보낸다.
         return ResponseEntity.ok(orderResponse);
     }
+
+    @PostMapping("/{orderId}/pay")
+    public ResponseEntity<OrderResponse> requestPay(@PathVariable Long orderId, @RequestHeader("Idempotency-Key") String idempotencyKey) {
+        Long juniorId = 1L; // 테스트용 id
+        OrderResponse orderResponse = orderService.payOrder(orderId, idempotencyKey, juniorId);
+        return ResponseEntity.ok(orderResponse);
+    }
 }

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -12,8 +12,11 @@ import com.knoc.member.MemberRepository;
 import com.knoc.order.dto.OrderRequest;
 import com.knoc.order.dto.OrderResponse;
 import com.knoc.order.entity.Order;
+import com.knoc.order.entity.OrderStatus;
 import com.knoc.order.repository.OrderRepository;
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,53 +26,106 @@ import java.util.UUID;
 @Transactional
 @RequiredArgsConstructor
 public class OrderService {
-    private final OrderRepository orderRepository;
-    private final ChatRoomRepository chatRoomRepository;
-    private final ChatMessageRepository chatMessageRepository;
-    private final MemberRepository memberRepository;
+        private final OrderRepository orderRepository;
+        private final ChatRoomRepository chatRoomRepository;
+        private final ChatMessageRepository chatMessageRepository;
+        private final MemberRepository memberRepository;
 
-    public OrderResponse createOrderRequest(OrderRequest dto, Long seniorId) {
-        // 1. 엔티티 조회 (채팅방, 주니어, 시니어)
-        ChatRoom chatRoom = chatRoomRepository.findById(dto.getChatRoomId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.CHATROOM_NOT_FOUND));
-        Member junior = memberRepository.findById(dto.getJuniorId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-        Member senior = memberRepository.findById(seniorId) // 시큐리티에서 넘겨받은 현재 사용자
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        public OrderResponse createOrderRequest(OrderRequest dto, Long seniorId) {
+                // 1. 엔티티 조회 (채팅방, 주니어, 시니어)
+                ChatRoom chatRoom = chatRoomRepository.findById(dto.getChatRoomId())
+                                .orElseThrow(() -> new BusinessException(ErrorCode.CHATROOM_NOT_FOUND));
+                Member junior = memberRepository.findById(dto.getJuniorId())
+                                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+                Member senior = memberRepository.findById(seniorId) // 시큐리티에서 넘겨받은 현재 사용자
+                                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
-        // 요청한 사람이 실제 해당 채팅방의 시니어가 맞는지 검증
-        if (!chatRoom.getSenior().getId().equals(seniorId)) {
-            throw new BusinessException(ErrorCode.NOT_SENIOR_IN_ROOM);
+                // 요청한 사람이 실제 해당 채팅방의 시니어가 맞는지 검증
+                if (!chatRoom.getSenior().getId().equals(seniorId)) {
+                        throw new BusinessException(ErrorCode.NOT_SENIOR_IN_ROOM);
+                }
+
+                // 2. 주문 번호 생성
+                String orderNumber = "ORD-" + UUID.randomUUID();
+
+                // 3. 주문 객체 생성 및 DB 저장
+                Order order = Order.builder()
+                                .orderNumber(orderNumber)
+                                .chatRoom(chatRoom)
+                                .junior(junior)
+                                .senior(senior)
+                                .amount(dto.getAmount())
+                                .build();
+
+                Order savedOrder = orderRepository.save(order);
+
+                // 4. 결제 요청 시스템 메시지 생성 및 저장
+                // 금액에 콤마 추가 (예: 55000 -> 55,000)
+                String formattedAmount = String.format("%,d", dto.getAmount());
+                ChatMessage message = ChatMessage.builder()
+                                .chatRoom(chatRoom)
+                                .messageType(MessageType.PAYMENT_REQUESTED)
+                                .content("시니어님이 " + formattedAmount
+                                                + "원 결제를 요청했습니다.\n결제를 완료하시면 상세 리뷰 요청서를 작성하실 수 있습니다.")
+                                .referenceId(savedOrder.getId()) // 주문 ID 연결
+                                .sender(null) // 시스템 메시지이므로 발신자는 null 또는 별도의 시스템 계정
+                                .build();
+
+                chatMessageRepository.save(message);
+
+                // 5. 저장된 주문을 클라이언트에게 보여줄 전용 응답 객체(DTO)로 변환
+                return OrderResponse.from(savedOrder);
         }
 
-        // 2. 주문 번호 생성
-        String orderNumber = "ORD-" + UUID.randomUUID();
+        public OrderResponse payOrder(Long orderId, String idempotencyKey, Long juniorId) {
+                // 입력 검증
+                if (idempotencyKey == null || idempotencyKey.isBlank() || juniorId == null) {
+                        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+                }
 
-        // 3. 주문 객체 생성 및 DB 저장
-        Order order = Order.builder()
-                .orderNumber(orderNumber)
-                .chatRoom(chatRoom)
-                .junior(junior)
-                .senior(senior)
-                .amount(dto.getAmount())
-                .build();
+                // 주문 조회
+                Order order = orderRepository.findById(orderId)
+                                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+                // String lockKey = "pay:" + order.getOrderNumber(); // 주문 생성 단계에서의 lockKey와 동일
+                // (같은 주문에 대한 작업을 같은 키로 직렬화)
 
-        Order savedOrder = orderRepository.save(order);
+                // 주니어 검증
+                if (!order.getJunior().getId().equals(juniorId)) {
+                        throw new BusinessException(ErrorCode.NOT_JUNIOR_FOR_ORDER);
+                }
 
-        // 4. 결제 요청 시스템 메시지 생성 및 저장
-        // 금액에 콤마 추가 (예: 55000 -> 55,000)
-        String formattedAmount = String.format("%,d", dto.getAmount());
-        ChatMessage message = ChatMessage.builder()
-                .chatRoom(chatRoom)
-                .messageType(MessageType.PAYMENT_REQUESTED)
-                .content("시니어님이 " + formattedAmount + "원 결제를 요청했습니다.\n결제를 완료하시면 상세 리뷰 요청서를 작성하실 수 있습니다.")
-                .referenceId(savedOrder.getId()) // 주문 ID 연결
-                .sender(null) // 시스템 메시지이므로 발신자는 null 또는 별도의 시스템 계정
-                .build();
+                // 상태 분기
+                if (order.getStatus() == OrderStatus.PAID) {
+                        return OrderResponse.from(order); // 결제 완료 메시지 중복 방지
+                } else if (order.getStatus() == OrderStatus.PENDING) {
+                        order.updateStatus(OrderStatus.PAID);
+                } else { // 그 외의 상태(SETTLED, CANCELLED)는 에러
+                        throw new BusinessException(ErrorCode.ORDER_CANNOT_BE_PAID);
+                }
+                // 저장 (낙관적 락 충돌 시: 재조회 후 멱등 성공/충돌 응답)
+                final Order savedOrder;
+                try {
+                    savedOrder = orderRepository.saveAndFlush(order);
+                } catch (OptimisticLockingFailureException e) {
+                    Order latest = orderRepository.findById(orderId)
+                            .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+                    if (latest.getStatus() == OrderStatus.PAID) {
+                        return OrderResponse.from(latest); // 이미 결제 처리 완료된 경우 멱등 성공 (200)
+                    }
+                    throw new BusinessException(ErrorCode.ORDER_PAYMENT_CONFLICT); // 아직 PAID가 아니라면 충돌(409)
+                }
 
-        chatMessageRepository.save(message);
+                ChatMessage message = ChatMessage.builder()
+                                .chatRoom(savedOrder.getChatRoom())
+                                .messageType(MessageType.PAYMENT_COMPLETED)
+                                .content("결제가 성공적으로 처리되었습니다.\n" +
+                                                "결제 금액은 구매 확정 시까지 Knoc에서 안전하게 보호합니다.")
+                                .referenceId(savedOrder.getId())
+                                .sender(null) // 시스템 메시지이므로 발신자는 null
+                                .build();
 
-        // 5. 저장된 주문을 클라이언트에게 보여줄 전용 응답 객체(DTO)로 변환
-        return OrderResponse.from(savedOrder);
-    }
+                chatMessageRepository.save(message);
+
+                return OrderResponse.from(savedOrder);
+        }
 }

--- a/src/test/java/com/knoc/order/service/OrderServiceTest.java
+++ b/src/test/java/com/knoc/order/service/OrderServiceTest.java
@@ -90,10 +90,10 @@ class OrderServiceTest {
         // Verify: 실제로 DB 저장 메서드가 '한 번' 호출되었는지 확인
         verify(orderRepository, times(1)).save(any(Order.class));
         // Verify: 결제 요청 시스템 메시지 내용 검증
-        verify(chatMessageRepository, times(1)).save(argThat(message ->
-                message.getMessageType() ==  MessageType.PAYMENT_REQUESTED && // 타입 확인
-                message.getContent().contains("50,000") && // 금액 포함 확인
-                message.getContent().contains("결제를 완료하시면"))); // 문구 포함 확인
+        verify(chatMessageRepository, times(1))
+                .save(argThat(message -> message.getMessageType() == MessageType.PAYMENT_REQUESTED && // 타입 확인
+                        message.getContent().contains("50,000") && // 금액 포함 확인
+                        message.getContent().contains("결제를 완료하시면"))); // 문구 포함 확인
     }
 
     @Test
@@ -140,6 +140,109 @@ class OrderServiceTest {
 
         // Verify: 예외 발생 시 어떠한 데이터 저장도 일어나지 않아야 함
         verify(orderRepository, never()).save(any());
+        verify(chatMessageRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("결제 성공: PENDING 주문이 PAID로 전이되고 결제완료 시스템 메시지가 1회 저장된다.")
+    void payOrder_Success_PendingToPaid() {
+        // given
+        Long orderId = 100L;
+        Long juniorId = 2L;
+        String idempotencyKey = "idem-123";
+
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        given(chatRoom.getId()).willReturn(10L);
+
+        Member junior = mock(Member.class);
+        given(junior.getId()).willReturn(juniorId);
+
+        Order order = Order.builder()
+                .orderNumber("ORD-TEST")
+                .chatRoom(chatRoom)
+                .junior(junior)
+                .senior(mock(Member.class))
+                .amount(50000)
+                .build(); // status = PENDING
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(orderRepository.saveAndFlush(any(Order.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        OrderResponse response = orderService.payOrder(orderId, idempotencyKey, juniorId);
+
+        // then
+        assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.PAID);
+
+        verify(orderRepository, times(1)).saveAndFlush(any(Order.class));
+        verify(chatMessageRepository, times(1))
+                .save(argThat(message -> message.getMessageType() == MessageType.PAYMENT_COMPLETED &&
+                        message.getContent().contains("결제가 성공적으로 처리되었습니다.")));
+    }
+
+    @Test
+    @DisplayName("결제 멱등: 이미 PAID면 저장/메시지 없이 그대로 응답한다.")
+    void payOrder_Idempotent_WhenAlreadyPaid() {
+        // given
+        Long orderId = 101L;
+        Long juniorId = 2L;
+        String idempotencyKey = "idem-456";
+
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        given(chatRoom.getId()).willReturn(10L);
+
+        Member junior = mock(Member.class);
+        given(junior.getId()).willReturn(juniorId);
+
+        Order order = Order.builder()
+                .orderNumber("ORD-PAID")
+                .chatRoom(chatRoom)
+                .junior(junior)
+                .senior(mock(Member.class))
+                .amount(50000)
+                .build();
+        order.updateStatus(OrderStatus.PAID);
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when
+        OrderResponse response = orderService.payOrder(orderId, idempotencyKey, juniorId);
+
+        // then
+        assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.PAID);
+
+        verify(orderRepository, never()).saveAndFlush(any());
+        verify(chatMessageRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("결제 실패: 주문의 주니어가 아니면 403 예외가 발생하고 저장/메시지가 발생하지 않는다.")
+    void payOrder_Fail_NotJunior() {
+        // given
+        Long orderId = 102L;
+        Long actualJuniorId = 2L;
+        Long attackerJuniorId = 999L;
+        String idempotencyKey = "idem-789";
+
+        Member junior = mock(Member.class);
+        given(junior.getId()).willReturn(actualJuniorId);
+
+        Order order = Order.builder()
+                .orderNumber("ORD-NOT-JUNIOR")
+                .chatRoom(mock(ChatRoom.class))
+                .junior(junior)
+                .senior(mock(Member.class))
+                .amount(50000)
+                .build();
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderService.payOrder(orderId, idempotencyKey, attackerJuniorId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.NOT_JUNIOR_FOR_ORDER.getMessage());
+
+        verify(orderRepository, never()).saveAndFlush(any());
         verify(chatMessageRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
## 🔎 What

- POST /orders/{orderId}/pay 엔드포인트 추가: 결제 완료 처리를 위한 라우팅 구현
- 결제 상태 전이 처리: PENDING → PAID 전이 및 결제 불가 상태(SETTLED/CANCELLED) 차단
- 시스템 메시지 저장: 결제 완료 시 MessageType.PAYMENT_COMPLETED 메시지 1회 생성/저장
- 멱등 처리: 이미 PAID인 주문은 저장/메시지 없이 OrderResponse로 그대로 응답
- 동시성(낙관적 락) 충돌 처리: 저장 충돌 시 재조회 후 PAID면 멱등 성공(200), 아니면 409(ORDER_PAYMENT_CONFLICT) 반환
- 에러 코드 추가: ORDER_CANNOT_BE_PAID(400), ORDER_PAYMENT_CONFLICT(409) 추가
- 단위 테스트 추가: payOrder 성공/멱등/권한(주니어 불일치) 케이스 3종 추가 및 통과

## 🔗 Issue

- Closes: #41 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?

