### PR TITLE
[feat] 토스페이먼츠 결제창 기반 결제 기능 연동

### DIFF
--- a/src/main/java/com/knoc/chat/entity/MessageType.java
+++ b/src/main/java/com/knoc/chat/entity/MessageType.java
@@ -13,7 +13,8 @@ public enum MessageType {
     // 아래부터는 이벤트 발생 시 템플릿에 들어갈 기본 문구
     SYSTEM("시스템 알림입니다."),
     PAYMENT_REQUESTED("결제 요청이 도착했습니다. 아래 버튼을 눌러 결제를 진행해주세요."),
-    PAYMENT_COMPLETED("결제가 완료되었습니다. 상세 리뷰 요청서 작성 버튼이 활성화되었습니다.");
+    PAYMENT_COMPLETED("결제가 완료되었습니다. 상세 리뷰 요청서 작성 버튼이 활성화되었습니다."),
+    PAYMENT_FAILED("결제가 실패하거나 취소되었습니다.");
 
     // 각 ENUM 상수가 품고 있을 기본 문구
     private final String defaultTemplate;

--- a/src/main/java/com/knoc/chat/entity/MessageType.java
+++ b/src/main/java/com/knoc/chat/entity/MessageType.java
@@ -11,7 +11,6 @@ public enum MessageType {
     USER(""),
 
     // 아래부터는 이벤트 발생 시 템플릿에 들어갈 기본 문구
-    SYSTEM("시스템 알림입니다."),
     PAYMENT_REQUESTED("시니어님이 %,d원 결제를 요청했습니다.\n결제를 완료하시면 상세 리뷰 요청서를 작성하실 수 있습니다."),
     PAYMENT_COMPLETED("결제가 성공적으로 처리되었습니다.\n결제 금액은 구매 확정 시까지 Knoc에서 안전하게 보호합니다."),
     PAYMENT_FAILED("결제가 실패하거나 취소되었습니다. 다시 시도해주세요."),

--- a/src/main/java/com/knoc/global/config/SecurityConfig.java
+++ b/src/main/java/com/knoc/global/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 // url 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         // [공통/비로그인] AUTH-01(로그인), POST-02(후기 목록 조회-비로그인 가능 명시)
-                        .requestMatchers("/", "/auth/**", "/error/**", "/reviews/posts", "/css/**", "/js/**", "/images/**", "/ws/**").permitAll()
+                        .requestMatchers("/", "/auth/**", "/error/**", "/reviews/posts", "/orders/payment/toss/**", "/css/**", "/js/**", "/images/**", "/ws/**").permitAll()
                         // [시니어 전용] PROF-01(프로필 관리), REV-02(리포트 제출), MY-02(시니어 마이페이지), ORD-01(결제 요청)
                         .requestMatchers("/senior/profile/**", "/reports/**", "/my/senior/**", "/orders/request").hasRole("SENIOR")
                         // [주니어 전용] CHAT-01(방생성), ORD-01/02(결제), REV-01(요청), SET-01(구매확정), POST-01(후기작성), MY-01(주니어 마이페이지)

--- a/src/main/java/com/knoc/global/controller/IndexController.java
+++ b/src/main/java/com/knoc/global/controller/IndexController.java
@@ -3,6 +3,7 @@ package com.knoc.global.controller;
 import com.knoc.senior.SeniorProfileService;
 import com.knoc.senior.dto.SeniorSearchCondition;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,11 +20,15 @@ public class IndexController {
 
     private final SeniorProfileService seniorProfileService;
 
+    @Value("${toss.payments.client-key:}")
+    private String tossClientKey;
+
     @GetMapping("/")
     public String index(@ModelAttribute SeniorSearchCondition condition, Model model) {
         model.addAttribute("seniors", seniorProfileService.searchProfiles(condition));
         model.addAttribute("condition", condition);
         model.addAttribute("popularSkills", POPULAR_SKILLS);
+        model.addAttribute("tossClientKey", tossClientKey);
         return "index";
     }
 }

--- a/src/main/java/com/knoc/global/exception/ErrorCode.java
+++ b/src/main/java/com/knoc/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     NOT_JUNIOR_FOR_ORDER(403, "해당 주문의 주니어가 아닙니다."), // 권한 검증용
     ORDER_CANNOT_BE_PAID(400, "현재 주문 상태에서는 결제를 진행할 수 없습니다."),
     ORDER_PAYMENT_CONFLICT(409, "동시에 결제가 시도되어 처리에 실패했습니다. 다시 시도해주세요."),
+    ORDER_PAYMENT_AMOUNT_MISMATCH(400, "결제 금액이 주문 금액과 일치하지 않습니다."),
 
     // 리뷰 관련 (Review)
     REVIEW_ALREADY_EXISTS(409, "이미 해당 주문에 대한 후기가 존재합니다."),

--- a/src/main/java/com/knoc/order/controller/OrderController.java
+++ b/src/main/java/com/knoc/order/controller/OrderController.java
@@ -31,7 +31,7 @@ public class OrderController {
     @PreAuthorize("hasRole('USER')")  // 주니어 결제 가능
     public ResponseEntity<OrderResponse> requestPay(@PathVariable Long orderId, @RequestHeader("Idempotency-Key") String idempotencyKey) {
         Long juniorId = 1L; // 테스트용 id
-        OrderResponse orderResponse = orderService.payOrder(orderId, idempotencyKey, juniorId);
+        OrderResponse orderResponse = orderService.preparePayment(orderId, idempotencyKey, juniorId);
         return ResponseEntity.ok(orderResponse);
     }
 }

--- a/src/main/java/com/knoc/order/controller/TossPaymentController.java
+++ b/src/main/java/com/knoc/order/controller/TossPaymentController.java
@@ -1,0 +1,135 @@
+package com.knoc.order.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.knoc.global.exception.BusinessException;
+import com.knoc.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+// 토스페이먼츠 테스트 결제:
+// - 결제 인증 성공 리다이렉트 후, 서버에서 결제 승인(confirm) API를 호출합니다.
+// - 시크릿 키는 서버에서만 사용합니다(브라우저로 내려가면 안 됨).
+@Controller
+@RequestMapping("/orders/payment/toss")
+@RequiredArgsConstructor
+public class TossPaymentController {
+
+    private final ObjectMapper objectMapper;
+    private final OrderService orderService;
+
+    @Value("${toss.payments.secret-key:}")
+    private String secretKey;
+
+    @GetMapping("/success")
+    @ResponseBody
+    public ResponseEntity<Void> success(
+            @RequestParam String paymentKey,
+            @RequestParam String orderId,
+            @RequestParam long amount) {
+        if (secretKey == null || secretKey.isBlank()) {
+            orderService.recordPaymentFailure(orderId, "서버 설정 오류로 결제 결과를 처리하지 못했습니다.");
+            // 토스 리다이렉트 착지 응답은 필요하지만, 결과 화면을 보여주지 않고 채팅방 시스템 메시지로 전달하기 때문에 302로 이동.
+            // (채팅 URL이 정해지면 여기 Location("/")만 채팅방 URL로 바꾸면 됨)
+            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
+        }
+
+        // Basic 인증: {secretKey}: 를 Base64 인코딩
+        String authHeader = "Basic " + Base64.getEncoder()
+                .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("paymentKey", paymentKey);
+        body.put("orderId", orderId);
+        body.put("amount", amount);
+
+        try {
+            String json = RestClient.create()
+                    .post()
+                    .uri("https://api.tosspayments.com/v1/payments/confirm") // <- 토스 서버로 승인 요청
+                    .header(HttpHeaders.AUTHORIZATION, authHeader)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .body(String.class);
+
+            JsonNode root = objectMapper.readTree(json);
+
+            long confirmedAmount = amount;
+            if (root.hasNonNull("totalAmount")) {
+                confirmedAmount = root.get("totalAmount").asLong();
+            }
+
+            // 성공 시: DB에 결제완료 반영 + 채팅 시스템 메시지 발송은 서비스에서 처리
+            orderService.confirmPayment(orderId, confirmedAmount);
+
+            // 토스 리다이렉트 착지 응답은 필요하지만, 결과 화면을 보여주지 않고 채팅방 시스템 메시지로 전달하기 때문에 302로 이동.
+            // (채팅 URL이 정해지면 여기 Location("/")만 채팅방 URL로 바꾸면 됨)
+            return ResponseEntity.status(302)
+                    .header(HttpHeaders.LOCATION, "/")
+                    .build();
+        } catch (RestClientResponseException e) {
+            orderService.recordPaymentFailure(orderId,
+                    parseTossErrorMessage(e.getResponseBodyAsString()));
+            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
+        } catch (BusinessException e) {
+            // confirm은 성공했는데 DB 반영이 실패한 케이스도 채팅 메시지로 남김
+            orderService.recordPaymentFailure(orderId, e.getMessage());
+            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
+        } catch (Exception e) {
+            orderService.recordPaymentFailure(orderId, e.getMessage());
+            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
+        }
+    }
+
+    @GetMapping("/fail")
+    @ResponseBody
+    public ResponseEntity<Void> fail(
+            @RequestParam(required = false) String code,
+            @RequestParam(required = false) String message,
+            @RequestParam(required = false) String orderId) {
+        String msg = message != null ? message : "결제가 취소되었거나 실패했습니다.";
+        if (code != null && !code.isBlank()) {
+            msg = msg + " (" + code + ")";
+        }
+        // 실패/취소도 채팅에 시스템 메시지로 남김
+        orderService.recordPaymentFailure(orderId, msg);
+
+        // 토스 리다이렉트 착지 응답은 필요하지만, 결과 화면을 보여주지 않고 채팅방 시스템 메시지로 전달하기 때문에 302로 이동.
+        // (채팅 URL이 정해지면 여기 Location("/")만 채팅방 URL로 바꾸면 됨)
+        return ResponseEntity.status(302)
+                .header(HttpHeaders.LOCATION, "/")
+                .build();
+    }
+
+    private String parseTossErrorMessage(String responseBody) {
+        if (responseBody == null || responseBody.isBlank()) {
+            return "결제 승인 요청이 거절되었습니다.";
+        }
+        try {
+            JsonNode n = objectMapper.readTree(responseBody);
+            String msg = n.path("message").asText(null);
+            if (msg != null && !msg.isBlank()) {
+                return msg;
+            }
+        } catch (Exception ignored) {
+            // 파싱 실패 시 원문 반환
+        }
+        return responseBody;
+    }
+}

--- a/src/main/java/com/knoc/order/entity/Order.java
+++ b/src/main/java/com/knoc/order/entity/Order.java
@@ -47,12 +47,6 @@ public class Order extends BaseEntity {
     @Column(nullable = false)
     private Long version;
 
-    private String kakaoTid;
-
-    private String paymentProvider;
-
-    private PaymentStatus paymentStatus;
-
     @Builder
     public Order(String orderNumber, ChatRoom chatRoom, Member junior, Member senior, int amount) {
         this.orderNumber = orderNumber;

--- a/src/main/java/com/knoc/order/entity/Order.java
+++ b/src/main/java/com/knoc/order/entity/Order.java
@@ -47,6 +47,12 @@ public class Order extends BaseEntity {
     @Column(nullable = false)
     private Long version;
 
+    private String kakaoTid;
+
+    private String paymentProvider;
+
+    private PaymentStatus paymentStatus;
+
     @Builder
     public Order(String orderNumber, ChatRoom chatRoom, Member junior, Member senior, int amount) {
         this.orderNumber = orderNumber;
@@ -56,7 +62,6 @@ public class Order extends BaseEntity {
         this.amount = amount;
         this.status = OrderStatus.PENDING;
     }
-
 
     // 상태 변경 가능 여부 확인 및 상태 전환
     public void updateStatus(OrderStatus toStatus) {
@@ -69,7 +74,7 @@ public class Order extends BaseEntity {
 
         switch (from) {
             case PENDING -> // 결제 대기 중에는 결재 완료 또는 취소만 가능
-                isPossible = (to == OrderStatus.PAID || to ==  OrderStatus.CANCELLED);
+                isPossible = (to == OrderStatus.PAID || to == OrderStatus.CANCELLED);
             case PAID -> // 결재 완료 중에는 정산 완료 또는 취소만 가능
                 isPossible = (to == OrderStatus.SETTLED || to == OrderStatus.CANCELLED);
             // SETTLED, CANCELLED(정산 완료, 취소)에서는 변경 불가능 -> isPossible = false

--- a/src/main/java/com/knoc/order/entity/PaymentStatus.java
+++ b/src/main/java/com/knoc/order/entity/PaymentStatus.java
@@ -1,0 +1,5 @@
+package com.knoc.order.entity;
+
+public enum PaymentStatus {
+    READY, APPROVED, CANCELLED, FAILED;
+}

--- a/src/main/java/com/knoc/order/entity/PaymentStatus.java
+++ b/src/main/java/com/knoc/order/entity/PaymentStatus.java
@@ -1,5 +1,0 @@
-package com.knoc.order.entity;
-
-public enum PaymentStatus {
-    READY, APPROVED, CANCELLED, FAILED;
-}

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.knoc.order.service;
 
 
+import com.knoc.chat.entity.ChatMessage;
 import com.knoc.chat.entity.ChatRoom;
 import com.knoc.chat.entity.ChatSystemEvent;
 import com.knoc.chat.entity.MessageType;
@@ -145,19 +146,16 @@ public class OrderService {
                 }
                 Order order = found.get();
 
-                String msg = (reason == null || reason.isBlank())
+                String customMessage = (reason == null || reason.isBlank())
                         ? "결제가 취소되었거나 실패했습니다.\n다시 시도해주세요."
                         : "결제가 취소되었거나 실패했습니다.\n사유: " + reason;
 
-                ChatMessage message = ChatMessage.builder()
-                        .chatRoom(order.getChatRoom())
-                        .messageType(MessageType.PAYMENT_FAILED)
-                        .content(msg)
-                        .referenceId(order.getId())
-                        .sender(null)
-                        .build();
-
-                chatMessageRepository.save(message);
+                eventPublisher.publishEvent(new ChatSystemEvent(
+                        order.getChatRoom().getId(),
+                        MessageType.PAYMENT_FAILED,
+                        customMessage,
+                        order.getId()
+                ));
         }
 
         // PG(토스 등) 승인 이후 공통 처리: PENDING -> PAID, 저장, 결제완료 시스템 메시지

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -28,170 +28,170 @@ import java.util.UUID;
 @Transactional
 @RequiredArgsConstructor
 public class OrderService {
-        private final OrderRepository orderRepository;
-        private final ChatRoomRepository chatRoomRepository;
-        private final MemberRepository memberRepository;
-        private final ApplicationEventPublisher eventPublisher;
+    private final OrderRepository orderRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
-        public OrderResponse createOrderRequest(OrderRequest dto, Long seniorId) {
-                // 1. 엔티티 조회 (채팅방, 주니어, 시니어)
-                ChatRoom chatRoom = chatRoomRepository.findById(dto.getChatRoomId())
-                                .orElseThrow(() -> new BusinessException(ErrorCode.CHATROOM_NOT_FOUND));
-                Member junior = memberRepository.findById(dto.getJuniorId())
-                                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-                Member senior = memberRepository.findById(seniorId) // 시큐리티에서 넘겨받은 현재 사용자
-                                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    public OrderResponse createOrderRequest(OrderRequest dto, Long seniorId) {
+        // 1. 엔티티 조회 (채팅방, 주니어, 시니어)
+        ChatRoom chatRoom = chatRoomRepository.findById(dto.getChatRoomId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHATROOM_NOT_FOUND));
+        Member junior = memberRepository.findById(dto.getJuniorId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        Member senior = memberRepository.findById(seniorId) // 시큐리티에서 넘겨받은 현재 사용자
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
-                // 요청한 사람이 실제 해당 채팅방의 시니어가 맞는지 검증
-                if (!chatRoom.getSenior().getId().equals(seniorId)) {
-                        throw new BusinessException(ErrorCode.NOT_SENIOR_IN_ROOM);
-                }
-
-                // 2. 주문 번호 생성
-                String orderNumber = "ORD-" + UUID.randomUUID();
-
-                // 3. 주문 객체 생성 및 DB 저장
-                Order order = Order.builder()
-                                .orderNumber(orderNumber)
-                                .chatRoom(chatRoom)
-                                .junior(junior)
-                                .senior(senior)
-                                .amount(dto.getAmount())
-                                .build();
-
-                Order savedOrder = orderRepository.save(order);
-
-                // 4. 결제 요청 시스템 메시지 생성 및 저장
-                // 금액에 콤마 추가 (예: 55000 -> 55,000)
-                String formattedAmount = String.format("%,d", dto.getAmount());
-                String customMessage = "시니어님이 " + formattedAmount + "원 결제를 요청했습니다.\n결제를 완료하시면 상세 리뷰 요청서를 작성하실 수 있습니다.";
-                eventPublisher.publishEvent(new ChatSystemEvent(
-                        chatRoom.getId(),
-                        MessageType.PAYMENT_REQUESTED,
-                        customMessage,
-                        savedOrder.getId()
-                ));
-                // 5. 저장된 주문을 클라이언트에게 보여줄 전용 응답 객체(DTO)로 변환
-                return OrderResponse.from(savedOrder);
+        // 요청한 사람이 실제 해당 채팅방의 시니어가 맞는지 검증
+        if (!chatRoom.getSenior().getId().equals(seniorId)) {
+            throw new BusinessException(ErrorCode.NOT_SENIOR_IN_ROOM);
         }
 
-        // 결제창 호출 전 단계(사전 검증/조회)
-        // 실제 결제 승인 후 처리는 confirmPayment(String, long) 메서드에서 수행
-        public OrderResponse preparePayment(Long orderId, String idempotencyKey, Long juniorId) {
-                // 입력 검증
-                if (idempotencyKey == null || idempotencyKey.isBlank() || juniorId == null) {
-                        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-                }
+        // 2. 주문 번호 생성
+        String orderNumber = "ORD-" + UUID.randomUUID();
 
-                // 주문 조회
-                if (orderId == null) {
-                        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-                }
-                Order order = orderRepository.findById(orderId)
-                                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+        // 3. 주문 객체 생성 및 DB 저장
+        Order order = Order.builder()
+                .orderNumber(orderNumber)
+                .chatRoom(chatRoom)
+                .junior(junior)
+                .senior(senior)
+                .amount(dto.getAmount())
+                .build();
 
-                // String lockKey = "pay:" + order.getOrderNumber(); // 주문 생성 단계에서의 lockKey와 동일
-                // (같은 주문에 대한 작업을 같은 키로 직렬화)
+        Order savedOrder = orderRepository.save(order);
 
-                // 주니어 검증
-                if (order.getJunior() == null || order.getJunior().getId() == null) {
-                        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-                }
-                if (!order.getJunior().getId().equals(juniorId)) {
-                        throw new BusinessException(ErrorCode.NOT_JUNIOR_FOR_ORDER);
-                }
+        // 4. 결제 요청 시스템 메시지 생성 및 저장
+        // 금액에 콤마 추가 (예: 55000 -> 55,000)
+        String formattedAmount = String.format("%,d", dto.getAmount());
+        String customMessage = "시니어님이 " + formattedAmount + "원 결제를 요청했습니다.\n결제를 완료하시면 상세 리뷰 요청서를 작성하실 수 있습니다.";
+        eventPublisher.publishEvent(new ChatSystemEvent(
+                chatRoom.getId(),
+                MessageType.PAYMENT_REQUESTED,
+                customMessage,
+                savedOrder.getId()
+        ));
+        // 5. 저장된 주문을 클라이언트에게 보여줄 전용 응답 객체(DTO)로 변환
+        return OrderResponse.from(savedOrder);
+    }
 
-                // 결제 가능 상태 검증
-                if (order.getStatus() == OrderStatus.PAID) {
-                        return OrderResponse.from(order); // 이미 결제 완료된 경우 멱등 성공 (200)
-                }
-                if (order.getStatus() != OrderStatus.PENDING) {
-                        throw new BusinessException(ErrorCode.ORDER_CANNOT_BE_PAID); // 결제 불가능한 상태
-                }
-
-                return OrderResponse.from(order); // 결제 가능한 상태
+    // 결제창 호출 전 단계(사전 검증/조회)
+    // 실제 결제 승인 후 처리는 confirmPayment(String, long) 메서드에서 수행
+    public OrderResponse preparePayment(Long orderId, String idempotencyKey, Long juniorId) {
+        // 입력 검증
+        if (idempotencyKey == null || idempotencyKey.isBlank() || juniorId == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
-        // 토스페이먼츠 결제 승인(confirm) 성공 후 호출
-        // tossOrderId는 결제 요청 시 넣은 주문번호로, OrderService의 orderNumber와 같아야 함
-        // 로컬에 해당 주문이 없으면(예: 메인 테스트용 TEST-...) Optional.empty() 를 반환
-        public Optional<OrderResponse> confirmPayment(String tossOrderId, long confirmedAmount) {
-                if (tossOrderId == null || tossOrderId.isBlank()) {
-                        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-                }
-                Optional<Order> found = orderRepository.findByOrderNumber(tossOrderId);
-                if (found.isEmpty()) {
-                        return Optional.empty();
-                }
-                Order order = found.get();
-                if (order.getAmount() != confirmedAmount) {
-                        throw new BusinessException(ErrorCode.ORDER_PAYMENT_AMOUNT_MISMATCH); // 결제 금액 불일치
-                }
-                return Optional.of(markPaid(order)); // 결제 완료 처리
+        // 주문 조회
+        if (orderId == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
+        // String lockKey = "pay:" + order.getOrderNumber(); // 주문 생성 단계에서의 lockKey와 동일
+        // (같은 주문에 대한 작업을 같은 키로 직렬화)
+
+        // 주니어 검증
+        if (order.getJunior() == null || order.getJunior().getId() == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (!order.getJunior().getId().equals(juniorId)) {
+            throw new BusinessException(ErrorCode.NOT_JUNIOR_FOR_ORDER);
         }
 
-        /**
-         * 토스 결제 실패/취소 리다이렉트 후 호출합니다.
-         * - 주문이 존재하면 채팅방에 시스템 메시지를 저장합니다.
-         * - 주문이 없으면(예: TEST-...) 아무 것도 하지 않습니다.
-         * - 주문 상태는 기본적으로 변경하지 않습니다(PENDING 유지).
-         */
-        public void recordPaymentFailure(String tossOrderId, String reason) {
-                if (tossOrderId == null || tossOrderId.isBlank()) {
-                        return; // 토스 fail 콜백에서 orderId가 없을 수 있어 조용히 무시
-                }
-                Optional<Order> found = orderRepository.findByOrderNumber(tossOrderId);
-                if (found.isEmpty()) {
-                        return;
-                }
-                Order order = found.get();
-
-                String customMessage = (reason == null || reason.isBlank())
-                        ? "결제가 취소되었거나 실패했습니다.\n다시 시도해주세요."
-                        : "결제가 취소되었거나 실패했습니다.\n사유: " + reason;
-
-                eventPublisher.publishEvent(new ChatSystemEvent(
-                        order.getChatRoom().getId(),
-                        MessageType.PAYMENT_FAILED,
-                        customMessage,
-                        order.getId()
-                ));
+        // 결제 가능 상태 검증
+        if (order.getStatus() == OrderStatus.PAID) {
+            return OrderResponse.from(order); // 이미 결제 완료된 경우 멱등 성공 (200)
+        }
+        if (order.getStatus() != OrderStatus.PENDING) {
+            throw new BusinessException(ErrorCode.ORDER_CANNOT_BE_PAID); // 결제 불가능한 상태
         }
 
-        // PG(토스 등) 승인 이후 공통 처리: PENDING -> PAID, 저장, 결제완료 시스템 메시지
-        private OrderResponse markPaid(Order order) {
-                Long orderId = order.getId();
+        return OrderResponse.from(order); // 결제 가능한 상태
+    }
 
-                // 상태 분기
-                if (order.getStatus() == OrderStatus.PAID) {
-                        return OrderResponse.from(order); // 결제 완료 메시지 중복 방지
-                } else if (order.getStatus() == OrderStatus.PENDING) {
-                        order.updateStatus(OrderStatus.PAID);
-                } else { // 그 외의 상태(SETTLED, CANCELLED)는 에러
-                        throw new BusinessException(ErrorCode.ORDER_CANNOT_BE_PAID);
-                }
-                // 저장 (낙관적 락 충돌 시: 재조회 후 멱등 성공/충돌 응답)
-                final Order savedOrder;
-                try {
-                        savedOrder = orderRepository.saveAndFlush(order);
-                } catch (OptimisticLockingFailureException e) {
-                        Order latest = orderRepository.findById(orderId)
-                                        .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-                        if (latest.getStatus() == OrderStatus.PAID) {
-                                return OrderResponse.from(latest); // 이미 결제 처리 완료된 경우 멱등 성공 (200)
-                        }
-                        throw new BusinessException(ErrorCode.ORDER_PAYMENT_CONFLICT); // 아직 PAID가 아니라면 충돌(409)
-                }
-
-                String customMessage = "결제가 성공적으로 처리되었습니다.\n결제 금액은 구매 확정 시까지 Knoc에서 안전하게 보호합니다.";
-
-                eventPublisher.publishEvent(new ChatSystemEvent(
-                        savedOrder.getChatRoom().getId(),
-                        MessageType.PAYMENT_COMPLETED,
-                        customMessage,
-                        savedOrder.getId()
-                ));
-
-                return OrderResponse.from(savedOrder);
+    // 토스페이먼츠 결제 승인(confirm) 성공 후 호출
+    // tossOrderId는 결제 요청 시 넣은 주문번호로, OrderService의 orderNumber와 같아야 함
+    // 로컬에 해당 주문이 없으면(예: 메인 테스트용 TEST-...) Optional.empty() 를 반환
+    public Optional<OrderResponse> confirmPayment(String tossOrderId, long confirmedAmount) {
+        if (tossOrderId == null || tossOrderId.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
+        Optional<Order> found = orderRepository.findByOrderNumber(tossOrderId);
+        if (found.isEmpty()) {
+            return Optional.empty();
+        }
+        Order order = found.get();
+        if (order.getAmount() != confirmedAmount) {
+            throw new BusinessException(ErrorCode.ORDER_PAYMENT_AMOUNT_MISMATCH); // 결제 금액 불일치
+        }
+        return Optional.of(markPaid(order)); // 결제 완료 처리
+    }
+
+    /**
+     * 토스 결제 실패/취소 리다이렉트 후 호출합니다.
+     * - 주문이 존재하면 채팅방에 시스템 메시지를 저장합니다.
+     * - 주문이 없으면(예: TEST-...) 아무 것도 하지 않습니다.
+     * - 주문 상태는 기본적으로 변경하지 않습니다(PENDING 유지).
+     */
+    public void recordPaymentFailure(String tossOrderId, String reason) {
+        if (tossOrderId == null || tossOrderId.isBlank()) {
+            return; // 토스 fail 콜백에서 orderId가 없을 수 있어 조용히 무시
+        }
+        Optional<Order> found = orderRepository.findByOrderNumber(tossOrderId);
+        if (found.isEmpty()) {
+            return;
+        }
+        Order order = found.get();
+
+        String customMessage = (reason == null || reason.isBlank())
+                ? "결제가 취소되었거나 실패했습니다.\n다시 시도해주세요."
+                : "결제가 취소되었거나 실패했습니다.\n사유: " + reason;
+
+        eventPublisher.publishEvent(new ChatSystemEvent(
+                order.getChatRoom().getId(),
+                MessageType.PAYMENT_FAILED,
+                customMessage,
+                order.getId()
+        ));
+    }
+
+    // PG(토스 등) 승인 이후 공통 처리: PENDING -> PAID, 저장, 결제완료 시스템 메시지
+    private OrderResponse markPaid(Order order) {
+        Long orderId = order.getId();
+
+        // 상태 분기
+        if (order.getStatus() == OrderStatus.PAID) {
+            return OrderResponse.from(order); // 결제 완료 메시지 중복 방지
+        } else if (order.getStatus() == OrderStatus.PENDING) {
+            order.updateStatus(OrderStatus.PAID);
+        } else { // 그 외의 상태(SETTLED, CANCELLED)는 에러
+            throw new BusinessException(ErrorCode.ORDER_CANNOT_BE_PAID);
+        }
+        // 저장 (낙관적 락 충돌 시: 재조회 후 멱등 성공/충돌 응답)
+        final Order savedOrder;
+        try {
+            savedOrder = orderRepository.saveAndFlush(order);
+        } catch (OptimisticLockingFailureException e) {
+            Order latest = orderRepository.findById(orderId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+            if (latest.getStatus() == OrderStatus.PAID) {
+                return OrderResponse.from(latest); // 이미 결제 처리 완료된 경우 멱등 성공 (200)
+            }
+            throw new BusinessException(ErrorCode.ORDER_PAYMENT_CONFLICT); // 아직 PAID가 아니라면 충돌(409)
+        }
+
+        String customMessage = "결제가 성공적으로 처리되었습니다.\n결제 금액은 구매 확정 시까지 Knoc에서 안전하게 보호합니다.";
+
+        eventPublisher.publishEvent(new ChatSystemEvent(
+                savedOrder.getChatRoom().getId(),
+                MessageType.PAYMENT_COMPLETED,
+                customMessage,
+                savedOrder.getId()
+        ));
+
+        return OrderResponse.from(savedOrder);
+    }
 }

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -14,13 +14,13 @@ import com.knoc.order.dto.OrderResponse;
 import com.knoc.order.entity.Order;
 import com.knoc.order.entity.OrderStatus;
 import com.knoc.order.repository.OrderRepository;
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -74,22 +74,95 @@ public class OrderService {
                 return OrderResponse.from(savedOrder);
         }
 
-        public OrderResponse payOrder(Long orderId, String idempotencyKey, Long juniorId) {
+        // 결제창 호출 전 단계(사전 검증/조회)
+        // 실제 결제 승인 후 처리는 confirmPayment(String, long) 메서드에서 수행
+        public OrderResponse preparePayment(Long orderId, String idempotencyKey, Long juniorId) {
                 // 입력 검증
                 if (idempotencyKey == null || idempotencyKey.isBlank() || juniorId == null) {
                         throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
                 }
 
                 // 주문 조회
+                if (orderId == null) {
+                        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+                }
                 Order order = orderRepository.findById(orderId)
                                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+
                 // String lockKey = "pay:" + order.getOrderNumber(); // 주문 생성 단계에서의 lockKey와 동일
                 // (같은 주문에 대한 작업을 같은 키로 직렬화)
 
                 // 주니어 검증
+                if (order.getJunior() == null || order.getJunior().getId() == null) {
+                        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+                }
                 if (!order.getJunior().getId().equals(juniorId)) {
                         throw new BusinessException(ErrorCode.NOT_JUNIOR_FOR_ORDER);
                 }
+
+                // 결제 가능 상태 검증
+                if (order.getStatus() == OrderStatus.PAID) {
+                        return OrderResponse.from(order); // 이미 결제 완료된 경우 멱등 성공 (200)
+                }
+                if (order.getStatus() != OrderStatus.PENDING) {
+                        throw new BusinessException(ErrorCode.ORDER_CANNOT_BE_PAID); // 결제 불가능한 상태
+                }
+
+                return OrderResponse.from(order); // 결제 가능한 상태
+        }
+
+        // 토스페이먼츠 결제 승인(confirm) 성공 후 호출
+        // tossOrderId는 결제 요청 시 넣은 주문번호로, OrderService의 orderNumber와 같아야 함
+        // 로컬에 해당 주문이 없으면(예: 메인 테스트용 TEST-...) Optional.empty() 를 반환
+        public Optional<OrderResponse> confirmPayment(String tossOrderId, long confirmedAmount) {
+                if (tossOrderId == null || tossOrderId.isBlank()) {
+                        throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+                }
+                Optional<Order> found = orderRepository.findByOrderNumber(tossOrderId);
+                if (found.isEmpty()) {
+                        return Optional.empty();
+                }
+                Order order = found.get();
+                if (order.getAmount() != confirmedAmount) {
+                        throw new BusinessException(ErrorCode.ORDER_PAYMENT_AMOUNT_MISMATCH); // 결제 금액 불일치
+                }
+                return Optional.of(markPaid(order)); // 결제 완료 처리
+        }
+
+        /**
+         * 토스 결제 실패/취소 리다이렉트 후 호출합니다.
+         * - 주문이 존재하면 채팅방에 시스템 메시지를 저장합니다.
+         * - 주문이 없으면(예: TEST-...) 아무 것도 하지 않습니다.
+         * - 주문 상태는 기본적으로 변경하지 않습니다(PENDING 유지).
+         */
+        public void recordPaymentFailure(String tossOrderId, String reason) {
+                if (tossOrderId == null || tossOrderId.isBlank()) {
+                        return; // 토스 fail 콜백에서 orderId가 없을 수 있어 조용히 무시
+                }
+                Optional<Order> found = orderRepository.findByOrderNumber(tossOrderId);
+                if (found.isEmpty()) {
+                        return;
+                }
+                Order order = found.get();
+
+                String msg = (reason == null || reason.isBlank())
+                        ? "결제가 취소되었거나 실패했습니다.\n다시 시도해주세요."
+                        : "결제가 취소되었거나 실패했습니다.\n사유: " + reason;
+
+                ChatMessage message = ChatMessage.builder()
+                        .chatRoom(order.getChatRoom())
+                        .messageType(MessageType.PAYMENT_FAILED)
+                        .content(msg)
+                        .referenceId(order.getId())
+                        .sender(null)
+                        .build();
+
+                chatMessageRepository.save(message);
+        }
+
+        // PG(토스 등) 승인 이후 공통 처리: PENDING -> PAID, 저장, 결제완료 시스템 메시지
+        private OrderResponse markPaid(Order order) {
+                Long orderId = order.getId();
 
                 // 상태 분기
                 if (order.getStatus() == OrderStatus.PAID) {
@@ -102,14 +175,14 @@ public class OrderService {
                 // 저장 (낙관적 락 충돌 시: 재조회 후 멱등 성공/충돌 응답)
                 final Order savedOrder;
                 try {
-                    savedOrder = orderRepository.saveAndFlush(order);
+                        savedOrder = orderRepository.saveAndFlush(order);
                 } catch (OptimisticLockingFailureException e) {
-                    Order latest = orderRepository.findById(orderId)
-                            .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-                    if (latest.getStatus() == OrderStatus.PAID) {
-                        return OrderResponse.from(latest); // 이미 결제 처리 완료된 경우 멱등 성공 (200)
-                    }
-                    throw new BusinessException(ErrorCode.ORDER_PAYMENT_CONFLICT); // 아직 PAID가 아니라면 충돌(409)
+                        Order latest = orderRepository.findById(orderId)
+                                        .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+                        if (latest.getStatus() == OrderStatus.PAID) {
+                                return OrderResponse.from(latest); // 이미 결제 처리 완료된 경우 멱등 성공 (200)
+                        }
+                        throw new BusinessException(ErrorCode.ORDER_PAYMENT_CONFLICT); // 아직 PAID가 아니라면 충돌(409)
                 }
 
                 String customMessage = "결제가 성공적으로 처리되었습니다.\n결제 금액은 구매 확정 시까지 Knoc에서 안전하게 보호합니다.";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,3 +32,9 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 
 # 허용하지 않는 도메인
 email.blocked-domains=naver.com,daum.net,kakao.com,hanmail.net
+
+# 토스페이먼츠 (결제창 방식)
+# - 클라이언트 키: 브라우저에서 결제창 SDK 초기화에 사용
+# - 시크릿 키: 서버에서 결제 승인(confirm)에만 사용
+toss.payments.client-key=${TOSS_CLIENT_KEY:}
+toss.payments.secret-key=${TOSS_SECRET_KEY:}

--- a/src/main/resources/static/js/toss-pay.js
+++ b/src/main/resources/static/js/toss-pay.js
@@ -1,0 +1,94 @@
+// 채팅 결제 버튼 등에서 재사용할 수 있도록 `window.startTossPayment(params)`를 제공.
+// 아래 토스페이먼츠 v2 standard SDK 스크립트가 먼저 로드되어 있어야 함.
+// <script src="https://js.tosspayments.com/v2/standard"></script>
+
+// 서버 렌더링(Thymeleaf 등)으로 아래 전역 값을 주입해 주세요.
+// window.__TOSS_CLIENT_KEY__ = /*[[${tossClientKey}]]*/ "";
+// window.__TOSS_SUCCESS_PATH__ = "/orders/payment/toss/success";
+// window.__TOSS_FAIL_PATH__ = "/orders/payment/toss/fail";
+
+(function () {
+  function getClientKey() {
+    return String(window.__TOSS_CLIENT_KEY__ || "");
+  }
+
+  function guestCustomerKey() {
+    var k = sessionStorage.getItem("tossCustomerKey");
+    if (!k) {
+      k = "guest_" + crypto.randomUUID();
+      sessionStorage.setItem("tossCustomerKey", k);
+    }
+    return k;
+  }
+
+  // 채팅 연동 시: 토스에 넘기는 orderId는 DB 주문의 orderNumber(예: ORD-...)와 동일해야 승인 후 Knoc 주문이 PAID로 반영됩니다.
+  function randomOrderId() {
+    return (
+      "TEST-" + Date.now() + "-" + Math.random().toString(36).slice(2, 10)
+    );
+  }
+
+  function getSuccessUrl() {
+    var path = String(window.__TOSS_SUCCESS_PATH__ || "/orders/payment/toss/success");
+    return window.location.origin + path;
+  }
+
+  function getFailUrl() {
+    var path = String(window.__TOSS_FAIL_PATH__ || "/orders/payment/toss/fail");
+    return window.location.origin + path;
+  }
+
+  window.startTossPayment = async function startTossPayment(params) {
+    var clientKey = getClientKey();
+    if (!clientKey) {
+      throw new Error("Toss clientKey가 설정되어 있지 않습니다.");
+    }
+    if (typeof TossPayments !== "function") {
+      throw new Error("TossPayments SDK가 로드되지 않았습니다.");
+    }
+
+    var amount = Number(params && params.amount != null ? params.amount : 15000);
+    var orderName = String(
+      params && params.orderName != null ? params.orderName : "Knoc 테스트 멘토링 결제"
+    );
+    var customerName = String(
+      params && params.customerName != null ? params.customerName : "테스트"
+    );
+    var orderId = String(params && params.orderId != null ? params.orderId : "");
+    if (!orderId) orderId = randomOrderId();
+
+    var tossPayments = TossPayments(clientKey);
+    var payment = tossPayments.payment({ customerKey: guestCustomerKey() });
+
+    await payment.requestPayment({
+      method: "CARD",
+      amount: { currency: "KRW", value: amount },
+      orderId: orderId,
+      orderName: orderName,
+      successUrl: getSuccessUrl(),
+      failUrl: getFailUrl(),
+      customerName: customerName,
+    });
+  };
+
+  // 기본 동작: index의 테스트 버튼이 있으면 자동 연결
+  document.addEventListener("DOMContentLoaded", function () {
+    var tossBtn = document.getElementById("tossTestPayBtn");
+    if (!tossBtn) return;
+    if (!getClientKey() || typeof TossPayments !== "function") return;
+
+    tossBtn.addEventListener("click", async function () {
+      try {
+        await window.startTossPayment({
+          amount: 15000,
+          orderName: "Knoc 테스트 멘토링 결제",
+          customerName: "테스트",
+        });
+      } catch (e) {
+        console.error(e);
+        alert("결제 요청 중 오류가 발생했습니다.");
+      }
+    });
+  });
+})();
+

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -4,6 +4,10 @@
       layout:decorate="~{layout/default_layout}">
 <head>
     <title>Knoc. 완벽한 사수를 만나는 가장 가벼운 노크</title>
+    <!-- 토스 SDK 스크립트 로드 -->
+    <th:block layout:fragment="head-extra">
+      <script src="https://js.tosspayments.com/v2/standard"></script>
+    </th:block>
 </head>
 
 <div layout:fragment="content">
@@ -16,6 +20,16 @@
             네카라쿠배 등 최정상 IT 기업의 시니어 개발자들과 함께하는 1:1 코드리뷰 &amp; 멘토링.<br>
             안전한 에스크로 결제와 통합 워크스페이스로 오직 성장에만 집중하세요.
         </p>
+
+        <!-- 토스페이먼츠 테스트 결제 (채팅 연동 전 임시) -->
+        <div class="mb-4">
+            <button type="button"
+                    id="tossTestPayBtn"
+                    class="btn btn-outline-light rounded-pill px-4 fw-semibold"
+                    th:attr="disabled=${tossClientKey == null or #strings.isEmpty(tossClientKey)}">
+                테스트 결제하기 (토스)
+            </button>
+        </div>
 
         <!-- 키워드 검색 -->
         <form th:action="@{/}" method="get" id="searchForm">
@@ -137,7 +151,7 @@
     </section>
 
 <th:block layout:fragment="script">
-    <script>
+    <script th:inline="javascript">
         const MAX_PRICE = 200000;
 
         function updateCareerDisplay(val) {
@@ -165,6 +179,12 @@
         }
 
         document.addEventListener('DOMContentLoaded', function () {
+            // 결제창 호출 로직은 `/js/toss-pay.js`에 분리되어 있고,
+            // 여기서는 서버에서 내려준 설정만 전역으로 주입합니다.
+            window.__TOSS_CLIENT_KEY__ = /*[[${tossClientKey}]]*/ "";
+            window.__TOSS_SUCCESS_PATH__ = "/orders/payment/toss/success";
+            window.__TOSS_FAIL_PATH__ = "/orders/payment/toss/fail";
+
             const careerSlider = document.getElementById('careerSlider');
             updateCareerDisplay(careerSlider.value);
             careerSlider.addEventListener('change', function () {
@@ -187,6 +207,7 @@
             }
         });
     </script>
+    <script src="/js/toss-pay.js"></script>
 </th:block>
 
     <!-- ── 시니어 목록 섹션 ──────────────────────────────── -->

--- a/src/test/java/com/knoc/order/OrderChatIntegrationTest.java
+++ b/src/test/java/com/knoc/order/OrderChatIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -89,7 +90,8 @@ public class OrderChatIntegrationTest {
                 .orderNumber("TEST-ORD").chatRoom(chatRoom).junior(junior).senior(senior).amount(55000).build());
 
         // when
-        OrderResponse response = orderService.payOrder(order.getId(), "idempotency-key", junior.getId());
+        OrderResponse response = orderService.confirmPayment(order.getOrderNumber(), order.getAmount())
+                .orElseThrow(() -> new NoSuchElementException("Order not found"));
 
         // then: 상태 변경 확인
         assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.PAID);

--- a/src/test/java/com/knoc/order/service/OrderServiceTest.java
+++ b/src/test/java/com/knoc/order/service/OrderServiceTest.java
@@ -153,8 +153,8 @@ class OrderServiceTest {
     }
 
     @Test
-    @DisplayName("결제 성공: PENDING 주문이 PAID로 전이되고 결제완료 시스템 메시지가 1회 저장된다.")
-    void payOrder_Success_PendingToPaid() {
+    @DisplayName("결제창 요청 성공: PENDING 주문이면 상태 변경 없이 주문 정보를 반환한다.")
+    void payOrder_Success_ReturnsOrderWithoutStateChange() {
         // given
         Long orderId = 100L;
         Long juniorId = 2L;
@@ -175,27 +175,21 @@ class OrderServiceTest {
                 .build(); // status = PENDING
 
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
-        given(orderRepository.saveAndFlush(any(Order.class))).willAnswer(inv -> inv.getArgument(0));
 
         // when
-        OrderResponse response = orderService.payOrder(orderId, idempotencyKey, juniorId);
+        OrderResponse response = orderService.preparePayment(orderId, idempotencyKey, juniorId);
 
         // then
-        assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.PAID);
-        verify(orderRepository, times(1)).saveAndFlush(any(Order.class));
+        assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.PENDING);
+        assertThat(response.getOrderNumber()).isEqualTo("ORD-TEST");
+        assertThat(response.getAmount()).isEqualTo(50000);
 
-        // 결제 완료 이벤트 검증
-        ArgumentCaptor<ChatSystemEvent> eventCaptor = ArgumentCaptor.forClass(ChatSystemEvent.class);
-        verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
-
-        ChatSystemEvent capturedEvent = eventCaptor.getValue();
-        assertThat(capturedEvent.type()).isEqualTo(MessageType.PAYMENT_COMPLETED);
-        assertThat(capturedEvent.customContent()).contains("결제가 성공적으로 처리되었습니다.");
+        verify(orderRepository, never()).saveAndFlush(any(Order.class));
 
     }
 
     @Test
-    @DisplayName("결제 멱등: 이미 PAID면 저장/메시지 없이 그대로 응답한다.")
+    @DisplayName("결제창 요청 멱등: 이미 PAID면 저장/메시지 없이 그대로 응답한다.")
     void payOrder_Idempotent_WhenAlreadyPaid() {
         // given
         Long orderId = 101L;
@@ -218,13 +212,52 @@ class OrderServiceTest {
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
         // when
-        OrderResponse response = orderService.payOrder(orderId, idempotencyKey, juniorId);
+        OrderResponse response = orderService.preparePayment(orderId, idempotencyKey, juniorId);
 
         // then
         assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.PAID);
 
         verify(orderRepository, never()).saveAndFlush(any());
         verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("결제 승인 성공: 토스 confirm 이후 호출되면 PENDING 주문이 PAID로 전이되고 결제완료 시스템 메시지가 1회 저장된다.")
+    void confirmPayment_Success_PendingToPaid() {
+        // given
+        String tossOrderId = "ORD-TEST";
+        long confirmedAmount = 50000L;
+
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        Member junior = mock(Member.class);
+
+        Order order = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(chatRoom)
+                .junior(junior)
+                .senior(mock(Member.class))
+                .amount((int) confirmedAmount)
+                .build(); // status = PENDING
+
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.of(order));
+        given(orderRepository.saveAndFlush(any(Order.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        Optional<OrderResponse> responseOpt = orderService.confirmPayment(tossOrderId, confirmedAmount);
+
+        // then
+        assertThat(responseOpt).isPresent();
+        assertThat(responseOpt.get().getOrderStatus()).isEqualTo(OrderStatus.PAID);
+
+        verify(orderRepository, times(1)).saveAndFlush(any(Order.class));
+
+        // 결제 완료 이벤트 검증
+        ArgumentCaptor<ChatSystemEvent> eventCaptor = ArgumentCaptor.forClass(ChatSystemEvent.class);
+        verify(eventPublisher, times(1)).publishEvent(eventCaptor.capture());
+
+        ChatSystemEvent capturedEvent = eventCaptor.getValue();
+        assertThat(capturedEvent.type()).isEqualTo(MessageType.PAYMENT_COMPLETED);
+        assertThat(capturedEvent.customContent()).contains("결제가 성공적으로 처리되었습니다.");
     }
 
     @Test
@@ -250,7 +283,7 @@ class OrderServiceTest {
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
         // when & then
-        assertThatThrownBy(() -> orderService.payOrder(orderId, idempotencyKey, attackerJuniorId))
+        assertThatThrownBy(() -> orderService.preparePayment(orderId, idempotencyKey, attackerJuniorId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.NOT_JUNIOR_FOR_ORDER.getMessage());
 


### PR DESCRIPTION
## 🔎 What

- 임시로 메인 화면에 결제 버튼을 만들어 토스페이먼츠 결제창 기반 결제 기능을 연동하였습니다.
- 카카오페이보단 토스페이먼츠가 공식 문서도 잘 되어 있고 가이드와 테스트 소스 코드도 제공해 주어서 토스페이먼츠를 사용하기로 변경하였습니다. (신용/체크카드는 구현 난이도가 훨씬 높아서 제외)
- develop 브랜치 리베이스해서 충돌 해결했습니다.

## .env 파일에 키 추가해야 함
- .env 파일에 토스페이먼츠에서 발급받은 API 키(클라이언트 키, 시크릿 키)를 추가해야 합니다.
토스페이먼츠 개발자센터 -> 내 개발정보 -> API 키 -> API 개별 연동 키 확인
```
# 토스페이먼츠
# 클라이언트 키: 프론트(index)에서 결제창 SDK 초기화에 사용
TOSS_CLIENT_KEY=
# 시크릿 키: 서버에서 결제 승인 API에만 사용 
TOSS_SECRET_KEY=
```

## 실행 화면
<img width="1137" height="624" alt="image" src="https://github.com/user-attachments/assets/7f2404a2-bfec-4847-97ef-f783b5552ce7" />
<img width="1294" height="867" alt="image" src="https://github.com/user-attachments/assets/d2bcad45-1ed3-46f4-9477-02e20b9792aa" />
<img width="1142" height="871" alt="image" src="https://github.com/user-attachments/assets/3f6fd34c-cdc5-4fc4-8b2b-256e1454b4cc" />
<img width="1042" height="832" alt="image" src="https://github.com/user-attachments/assets/66dd2846-1000-49f4-8bbd-b8715a00be68" />
<img width="1122" height="871" alt="image" src="https://github.com/user-attachments/assets/6035a3d7-1960-4782-a7b5-aba1c143b0d9" />

## 🔗 Issue

- Closes: #50 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?

