### PR TITLE
[feat] 중복 주문 요청 방지를 위한 멱등성 구현

### DIFF
--- a/src/main/java/com/knoc/global/exception/ErrorCode.java
+++ b/src/main/java/com/knoc/global/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     ORDER_CANNOT_BE_PAID(400, "현재 주문 상태에서는 결제를 진행할 수 없습니다."),
     ORDER_PAYMENT_CONFLICT(409, "동시에 결제가 시도되어 처리에 실패했습니다. 다시 시도해주세요."),
     ORDER_PAYMENT_AMOUNT_MISMATCH(400, "결제 금액이 주문 금액과 일치하지 않습니다."),
+    INVALID_IDEMPOTENCY_KEY(400, "유효하지 않은 멱등성 키입니다."),
 
     // 리뷰 관련 (Review)
     REVIEW_ALREADY_EXISTS(409, "이미 해당 주문에 대한 후기가 존재합니다."),

--- a/src/main/java/com/knoc/order/controller/OrderController.java
+++ b/src/main/java/com/knoc/order/controller/OrderController.java
@@ -16,12 +16,12 @@ public class OrderController {
 
     @PostMapping("/request")
     @PreAuthorize("hasRole('SENIOR')") // 시니어만 결제 요청 가능
-    public ResponseEntity<OrderResponse> requestOrder(@RequestBody OrderRequest dto) {
+    public ResponseEntity<OrderResponse> requestOrder(@RequestBody OrderRequest dto, @RequestHeader("Idempotency-Key") String idempotencyKey) {
         // 1. 현재 로그인한 시니어 ID를 가져온다.
         Long seniorId = 1L; // 테스트용 id
 
         // 2. 서비스를 호출하여 주문을 생성하고 응답 DTO를 받는다.
-        OrderResponse orderResponse = orderService.createOrderRequest(dto, seniorId);
+        OrderResponse orderResponse = orderService.createOrderRequest(dto, seniorId, idempotencyKey);
 
         // 3. 생성된 주문 정보(JSON 데이터로 변환됨)와 함께 200 OK 응답을 브라우저로 보낸다.
         return ResponseEntity.ok(orderResponse);

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -20,6 +20,7 @@ import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.Optional;
 
@@ -32,10 +33,10 @@ public class OrderService {
     private final MemberRepository memberRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @Transactional
     public OrderResponse createOrderRequest(OrderRequest dto, Long seniorId, String idempotencyKey) {
         // 0. 멱등키 검증 (비어있거나 너무 짧은 경우에 대한 에러 처리)
-        if (idempotencyKey == null || idempotencyKey.length() < 10) {
+        if (!StringUtils.hasText(idempotencyKey) || idempotencyKey.trim().length() < 10) {
             throw new BusinessException(ErrorCode.INVALID_IDEMPOTENCY_KEY);
         }
 
@@ -69,7 +70,7 @@ public class OrderService {
                             .build();
 
                     Order savedOrder;
-                    try {
+                    try { // saveAndFlush를 통해 즉시 쿼리를 날려 충돌을 감지함
                         savedOrder = orderRepository.saveAndFlush(order);
                     } catch (DataIntegrityViolationException e) { // 데이터 무결성 제약 조건을 위반했을 때 발생하는 예외
                         // 동시 요청으로 인해 UNIQUE 제약조건 위반 시, 이미 저장된 주문을 다시 찾아 반환

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -1,7 +1,6 @@
 package com.knoc.order.service;
 
 
-import com.knoc.chat.entity.ChatMessage;
 import com.knoc.chat.entity.ChatRoom;
 import com.knoc.chat.entity.ChatSystemEvent;
 import com.knoc.chat.entity.MessageType;
@@ -17,12 +16,12 @@ import com.knoc.order.entity.OrderStatus;
 import com.knoc.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
-import java.util.UUID;
 
 @Service
 @Transactional
@@ -33,46 +32,63 @@ public class OrderService {
     private final MemberRepository memberRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    public OrderResponse createOrderRequest(OrderRequest dto, Long seniorId) {
-        // 1. 엔티티 조회 (채팅방, 주니어, 시니어)
-        ChatRoom chatRoom = chatRoomRepository.findById(dto.getChatRoomId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.CHATROOM_NOT_FOUND));
-        Member junior = memberRepository.findById(dto.getJuniorId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-        Member senior = memberRepository.findById(seniorId) // 시큐리티에서 넘겨받은 현재 사용자
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
-
-        // 요청한 사람이 실제 해당 채팅방의 시니어가 맞는지 검증
-        if (!chatRoom.getSenior().getId().equals(seniorId)) {
-            throw new BusinessException(ErrorCode.NOT_SENIOR_IN_ROOM);
+    public OrderResponse createOrderRequest(OrderRequest dto, Long seniorId, String idempotencyKey) {
+        // 0. 멱등키 검증 (비어있거나 너무 짧은 경우에 대한 에러 처리)
+        if (idempotencyKey == null || idempotencyKey.length() < 10) {
+            throw new BusinessException(ErrorCode.INVALID_IDEMPOTENCY_KEY);
         }
 
-        // 2. 주문 번호 생성
-        String orderNumber = "ORD-" + UUID.randomUUID();
+        // 1. 멱등키를 기반으로 주문 번호 생성
+        String orderNumber = "ORD-" + idempotencyKey;
 
-        // 3. 주문 객체 생성 및 DB 저장
-        Order order = Order.builder()
-                .orderNumber(orderNumber)
-                .chatRoom(chatRoom)
-                .junior(junior)
-                .senior(senior)
-                .amount(dto.getAmount())
-                .build();
+        // 2. 멱등성 체크: 이미 해당 키로 생성된 주문이 있는지 확인
+        return orderRepository.findByOrderNumber(orderNumber)
+                .map(OrderResponse::from) // 있다면 바로 반환
+                .orElseGet(() -> { // 없다면 주문 객체 생성, 시스템 이벤트 발행
+                    // 3. 엔티티 조회 및 검증 (채팅방, 주니어, 시니어)
+                    ChatRoom chatRoom = chatRoomRepository.findById(dto.getChatRoomId())
+                            .orElseThrow(() -> new BusinessException(ErrorCode.CHATROOM_NOT_FOUND));
+                    Member junior = memberRepository.findById(dto.getJuniorId())
+                            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+                    Member senior = memberRepository.findById(seniorId) // 시큐리티에서 넘겨받은 현재 사용자
+                            .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
-        Order savedOrder = orderRepository.save(order);
+                    // 요청한 사람이 실제 해당 채팅방의 시니어가 맞는지 검증
+                    if (!chatRoom.getSenior().getId().equals(seniorId)) {
+                        throw new BusinessException(ErrorCode.NOT_SENIOR_IN_ROOM);
+                    }
 
-        // 4. 결제 요청 시스템 메시지 생성 및 저장
-        // 금액에 콤마 추가 (예: 55000 -> 55,000)
-        String formattedAmount = String.format("%,d", dto.getAmount());
-        String customMessage = MessageType.PAYMENT_REQUESTED.formatMessage(dto.getAmount());
-        eventPublisher.publishEvent(new ChatSystemEvent(
-                chatRoom.getId(),
-                MessageType.PAYMENT_REQUESTED,
-                customMessage,
-                savedOrder.getId()
-        ));
-        // 5. 저장된 주문을 클라이언트에게 보여줄 전용 응답 객체(DTO)로 변환
-        return OrderResponse.from(savedOrder);
+                    // 4. 주문 객체 생성 및 DB 저장
+                    Order order = Order.builder()
+                            .orderNumber(orderNumber)
+                            .chatRoom(chatRoom)
+                            .junior(junior)
+                            .senior(senior)
+                            .amount(dto.getAmount())
+                            .build();
+
+                    Order savedOrder;
+                    try {
+                        savedOrder = orderRepository.saveAndFlush(order);
+                    } catch (DataIntegrityViolationException e) { // 데이터 무결성 제약 조건을 위반했을 때 발생하는 예외
+                        // 동시 요청으로 인해 UNIQUE 제약조건 위반 시, 이미 저장된 주문을 다시 찾아 반환
+                        return orderRepository.findByOrderNumber(orderNumber)
+                                .map(OrderResponse::from)
+                                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+                    }
+
+                    // 5. 결제 요청 메시지 생성 및 시스템 이벤트 발행
+                    String formattedAmount = String.format("%,d", dto.getAmount()); // 금액에 콤마 추가 (예: 55000 -> 55,000)
+                    String customMessage = MessageType.PAYMENT_REQUESTED.formatMessage(formattedAmount);
+                    eventPublisher.publishEvent(new ChatSystemEvent(
+                            chatRoom.getId(),
+                            MessageType.PAYMENT_REQUESTED,
+                            customMessage,
+                            savedOrder.getId()
+                    ));
+                    // 6. 저장된 주문을 클라이언트에게 보여줄 전용 응답 객체(DTO)로 변환
+                    return OrderResponse.from(savedOrder);
+                });
         }
 
     // 결제창 호출 전 단계(사전 검증/조회)
@@ -130,12 +146,10 @@ public class OrderService {
         return Optional.of(markPaid(order)); // 결제 완료 처리
     }
 
-    /**
-     * 토스 결제 실패/취소 리다이렉트 후 호출합니다.
-     * - 주문이 존재하면 채팅방에 시스템 메시지를 저장합니다.
-     * - 주문이 없으면(예: TEST-...) 아무 것도 하지 않습니다.
-     * - 주문 상태는 기본적으로 변경하지 않습니다(PENDING 유지).
-     */
+    // 토스 결제 실패/취소 리다이렉트 후 호출합니다.
+    // 주문이 존재하면 채팅방에 시스템 메시지를 저장합니다.
+    // 주문이 없으면(예: TEST-...) 아무 것도 하지 않습니다.
+    // 주문 상태는 기본적으로 변경하지 않습니다(PENDING 유지).
     public void recordPaymentFailure(String tossOrderId, String reason) {
         if (tossOrderId == null || tossOrderId.isBlank()) {
             return; // 토스 fail 콜백에서 orderId가 없을 수 있어 조용히 무시
@@ -148,7 +162,7 @@ public class OrderService {
 
         String customMessage = (reason == null || reason.isBlank())
                 ? MessageType.PAYMENT_FAILED.getTemplate()
-                : "결제가 취소되었거나 실패했습니다.\n사유: " + reason;
+                : MessageType.PAYMENT_FAILED.getTemplate() + "\n사유: " + reason;
 
         eventPublisher.publishEvent(new ChatSystemEvent(
                 order.getChatRoom().getId(),
@@ -183,8 +197,8 @@ public class OrderService {
             throw new BusinessException(ErrorCode.ORDER_PAYMENT_CONFLICT); // 아직 PAID가 아니라면 충돌(409)
         }
 
+        // 결제 완료 메시지 생성 및 시스템 이벤트 발행
         String customMessage = MessageType.PAYMENT_COMPLETED.getTemplate();
-
         eventPublisher.publishEvent(new ChatSystemEvent(
                 savedOrder.getChatRoom().getId(),
                 MessageType.PAYMENT_COMPLETED,

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -1,6 +1,5 @@
 package com.knoc.order.service;
 
-
 import com.knoc.chat.entity.ChatRoom;
 import com.knoc.chat.entity.ChatSystemEvent;
 import com.knoc.chat.entity.MessageType;
@@ -19,6 +18,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -32,6 +32,7 @@ public class OrderService {
     private final MemberRepository memberRepository;
     private final ApplicationEventPublisher eventPublisher;
 
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public OrderResponse createOrderRequest(OrderRequest dto, Long seniorId, String idempotencyKey) {
         // 0. 멱등키 검증 (비어있거나 너무 짧은 경우에 대한 에러 처리)
         if (idempotencyKey == null || idempotencyKey.length() < 10) {
@@ -88,7 +89,7 @@ public class OrderService {
                     // 6. 저장된 주문을 클라이언트에게 보여줄 전용 응답 객체(DTO)로 변환
                     return OrderResponse.from(savedOrder);
                 });
-        }
+    }
 
     // 결제창 호출 전 단계(사전 검증/조회)
     // 실제 결제 승인 후 처리는 confirmPayment(String, long) 메서드에서 수행

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -95,7 +95,10 @@ public class OrderService {
     // 실제 결제 승인 후 처리는 confirmPayment(String, long) 메서드에서 수행
     public OrderResponse preparePayment(Long orderId, String idempotencyKey, Long juniorId) {
         // 입력 검증
-        if (idempotencyKey == null || idempotencyKey.isBlank() || juniorId == null) {
+        if (!StringUtils.hasText(idempotencyKey) || idempotencyKey.trim().length() < 10) {
+            throw new BusinessException(ErrorCode.INVALID_IDEMPOTENCY_KEY);
+        }
+        if(juniorId == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -18,7 +18,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -78,8 +78,7 @@ public class OrderService {
                     }
 
                     // 5. 결제 요청 메시지 생성 및 시스템 이벤트 발행
-                    String formattedAmount = String.format("%,d", dto.getAmount()); // 금액에 콤마 추가 (예: 55000 -> 55,000)
-                    String customMessage = MessageType.PAYMENT_REQUESTED.formatMessage(formattedAmount);
+                    String customMessage = MessageType.PAYMENT_REQUESTED.formatMessage(dto.getAmount());
                     eventPublisher.publishEvent(new ChatSystemEvent(
                             chatRoom.getId(),
                             MessageType.PAYMENT_REQUESTED,

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html
   xmlns:th="http://www.thymeleaf.org"
   xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6"

--- a/src/test/java/com/knoc/order/OrderChatIntegrationTest.java
+++ b/src/test/java/com/knoc/order/OrderChatIntegrationTest.java
@@ -68,7 +68,7 @@ public class OrderChatIntegrationTest {
         OrderRequest request = new OrderRequest(chatRoom.getId(), junior.getId(), 55000);
 
         // when
-        OrderResponse response = orderService.createOrderRequest(request, senior.getId());
+        OrderResponse response = orderService.createOrderRequest(request, senior.getId(), "idempotencyKey");
 
         // then: DTO 확인
         assertThat(response.getAmount()).isEqualTo(55000);

--- a/src/test/java/com/knoc/order/service/OrderServiceTest.java
+++ b/src/test/java/com/knoc/order/service/OrderServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Optional;
 
@@ -75,9 +76,9 @@ class OrderServiceTest {
 
         // Stubbing: 데이터 저장 로직 모의 처리
         // willAnswer를 사용하여 저장 시도된 Order 객체를 ID값만 임의로 채워 반환 (referenceId 확인용)
-        given(orderRepository.save(any(Order.class))).willAnswer(invocation -> {
-            // 실제 DB 저장이 아니므로 Reflection 등을 쓰지 않고 객체 그대로 반환
-            // (Service에서 savedOrder.getId()를 쓰므로 이 테스트 환경에서는 null이 반환되어도 로직은 수행됨)
+        given(orderRepository.saveAndFlush(any(Order.class))).willAnswer(invocation -> {
+            Order order = invocation.getArgument(0);
+            org.springframework.test.util.ReflectionTestUtils.setField(order, "id", 1L);
             return invocation.getArgument(0);
         });
 
@@ -91,7 +92,7 @@ class OrderServiceTest {
         assertThat(response.getOrderNumber()).startsWith("ORD-");
 
         // Verify: 실제로 DB 저장 메서드가 '한 번' 호출되었는지 확인
-        verify(orderRepository, times(1)).save(any(Order.class));
+        verify(orderRepository, times(1)).saveAndFlush(any(Order.class));
         // Verify: 결제 요청 시스템 메시지 내용 검증
         // 직접 저장(Repository) 대신 이벤트 발행 여부 검증
         // ArgumentCaptor를 사용해 발행된 이벤트를 낚아챔.
@@ -131,7 +132,7 @@ class OrderServiceTest {
                 .hasMessage(ErrorCode.NOT_SENIOR_IN_ROOM.getMessage()); // 메시지도 일치해야 함
 
         // Verify: 예외 발생 시 어떠한 데이터 저장도 일어나지 않아야 함
-        verify(orderRepository, never()).save(any());
+        verify(orderRepository, never()).saveAndFlush(any());
         verify(eventPublisher, never()).publishEvent(any()); // 실패 시 이벤트 발행 안 됨
     }
 
@@ -148,7 +149,7 @@ class OrderServiceTest {
                 .hasMessage(ErrorCode.CHATROOM_NOT_FOUND.getMessage());
 
         // Verify: 예외 발생 시 어떠한 데이터 저장도 일어나지 않아야 함
-        verify(orderRepository, never()).save(any());
+        verify(orderRepository, never()).saveAndFlush(any());
         verify(eventPublisher, never()).publishEvent(any());
     }
 
@@ -289,5 +290,76 @@ class OrderServiceTest {
 
         verify(orderRepository, never()).saveAndFlush(any());
         verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("결제 요청 실패: 멱등키가 너무 짧으면 예외가 발생한다.")
+    void createOrderRequest_Fail_InvalidIdempotencyKey() {
+        // given
+        String shortKey = "short"; // 10자 미만
+        OrderRequest request = new OrderRequest(1L, 2L, 50000);
+
+        // when & then
+        assertThatThrownBy(() -> orderService.createOrderRequest(request, 1L, shortKey))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_IDEMPOTENCY_KEY.getMessage());
+
+        verify(orderRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    @DisplayName("결제 요청 멱등: 동시에 두 요청이 들어와 DB 충돌이 발생해도 기존 주문을 반환한다.")
+    void createOrderRequest_Success_WhenConcurrencyConflict() {
+        // given
+        Long seniorId = 1L;
+        Long juniorId = 2L;
+        OrderRequest request = new OrderRequest(10L, juniorId, 50000);
+        String idempotencyKey = "idempotency-789";
+        String orderNumber = "ORD-" + idempotencyKey;
+
+        // 1. 필요한 연관 엔티티들을 Mock으로 준비 (OrderResponse.from에서 필드 추출 시 필요)
+        ChatRoom mockChatRoom = mock(ChatRoom.class);
+        given(mockChatRoom.getId()).willReturn(10L);
+
+        Member mockJunior = mock(Member.class);
+
+        Member mockSenior = mock(Member.class);
+        given(mockSenior.getId()).willReturn(1L);
+
+        // 2. 실제 Order 객체 생성 (Mock 대신 Builder 사용)
+        Order existingOrder = Order.builder()
+                .orderNumber(orderNumber)
+                .amount(50000)
+                .chatRoom(mockChatRoom)
+                .junior(mockJunior)
+                .senior(mockSenior)
+                .build();
+
+        // 만약 필드에 직접 접근하거나 getId() 등이 필요하면 ReflectionTestUtils 사용
+        org.springframework.test.util.ReflectionTestUtils.setField(existingOrder, "id", 100L);
+
+        // 3. Stubbing 설정
+        given(orderRepository.findByOrderNumber(orderNumber))
+                .willReturn(Optional.empty()) // 첫번째 조회: Optional.empty 반환
+                .willReturn(Optional.of(existingOrder)); // 두번째 조회: existingOrder 반환
+
+        // 저장 시도 시 누군가 먼저 저장해서 충돌 발생
+        given(orderRepository.saveAndFlush(any(Order.class)))
+                .willThrow(new DataIntegrityViolationException("Duplicate Entry"));
+
+        // 나머지 엔티티 조회 Stubbing (orElseGet 내부 진입 시 필요)
+        given(chatRoomRepository.findById(anyLong())).willReturn(Optional.of(mockChatRoom));
+        given(memberRepository.findById(juniorId)).willReturn(Optional.of(mockJunior));
+        given(memberRepository.findById(seniorId)).willReturn(Optional.of(mockSenior));
+
+        given(mockChatRoom.getSenior()).willReturn(mockSenior);
+
+        // when
+        OrderResponse response = orderService.createOrderRequest(request, seniorId, idempotencyKey);
+
+        // then
+        assertThat(response.getOrderNumber()).isEqualTo(orderNumber);
+        assertThat(response.getAmount()).isEqualTo(50000);
+        verify(orderRepository, times(2)).findByOrderNumber(orderNumber); // 처음 + catch문 재조회
     }
 }

--- a/src/test/java/com/knoc/order/service/OrderServiceTest.java
+++ b/src/test/java/com/knoc/order/service/OrderServiceTest.java
@@ -159,7 +159,7 @@ class OrderServiceTest {
         // given
         Long orderId = 100L;
         Long juniorId = 2L;
-        String idempotencyKey = "idem-123";
+        String idempotencyKey = "idempotencyKey-123";
 
         ChatRoom chatRoom = mock(ChatRoom.class);
         given(chatRoom.getId()).willReturn(10L);
@@ -195,7 +195,7 @@ class OrderServiceTest {
         // given
         Long orderId = 101L;
         Long juniorId = 2L;
-        String idempotencyKey = "idem-456";
+        String idempotencyKey = "idempotencyKey-456";
 
         ChatRoom chatRoom = mock(ChatRoom.class);
         Member junior = mock(Member.class);
@@ -268,7 +268,7 @@ class OrderServiceTest {
         Long orderId = 102L;
         Long actualJuniorId = 2L;
         Long attackerJuniorId = 999L;
-        String idempotencyKey = "idem-789";
+        String idempotencyKey = "idempotencyKey-789";
 
         Member junior = mock(Member.class);
         given(junior.getId()).willReturn(actualJuniorId);

--- a/src/test/java/com/knoc/order/service/OrderServiceTest.java
+++ b/src/test/java/com/knoc/order/service/OrderServiceTest.java
@@ -82,7 +82,7 @@ class OrderServiceTest {
         });
 
         // when
-        OrderResponse response = orderService.createOrderRequest(request, seniorId);
+        OrderResponse response = orderService.createOrderRequest(request, seniorId, "idempotencyKey");
 
         // then
         assertThat(response).isNotNull();
@@ -126,7 +126,7 @@ class OrderServiceTest {
         given(memberRepository.findById(anyLong())).willReturn(Optional.of(mock(Member.class)));
 
         // when & then
-        assertThatThrownBy(() -> orderService.createOrderRequest(request, hackerId))
+        assertThatThrownBy(() -> orderService.createOrderRequest(request, hackerId, "idempotencyKey"))
                 .isInstanceOf(BusinessException.class) // BusinessException이 터져야 함
                 .hasMessage(ErrorCode.NOT_SENIOR_IN_ROOM.getMessage()); // 메시지도 일치해야 함
 
@@ -143,7 +143,7 @@ class OrderServiceTest {
         OrderRequest request = new OrderRequest(1L, 2L, 10000);
 
         // when & then
-        assertThatThrownBy(() -> orderService.createOrderRequest(request, 1L))
+        assertThatThrownBy(() -> orderService.createOrderRequest(request, 1L, "idempotencyKey"))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.CHATROOM_NOT_FOUND.getMessage());
 


### PR DESCRIPTION
## 🔎 What

- 기존에 PR 올렸던 MySQL 네임드 기반 방식을 폐기하고, DB 제약 조건과 멱등키를 조합한 경량화된 멱등성 로직으로 재구현 했습니다.
- **멱등성 보장**: POST /orders/request API 헤더(Idempotency-Key)를 통해 전달받은 고유 키를 주문번호(ORD-UUID)로 사용하여, 동일 요청에 대해 중복 주문이 생성되지 않도록 보장합니다.
- **동시성 제어**: DB의 UNIQUE 제약 조건을 활용하여 찰나의 순간에 들어오는 중복 요청을 차단하며, 충돌 발생 시(DataIntegrityViolationException) 기존 주문을 재조회하여 반환하는 방식으로 안정성을 높였습니다.
- **예외 처리**: 유효하지 않은 멱등키(누락 또는 길이 미달)에 대해 400 응답을 반환하는 로직을 추가했습니다.

## 🔗 Issue

- Closes: #63 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?

