### PR TITLE
[feat] 결제 승인 단계 멱등성 보장

### DIFF
--- a/src/main/java/com/knoc/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/knoc/chat/repository/ChatMessageRepository.java
@@ -1,7 +1,12 @@
 package com.knoc.chat.repository;
 
 import com.knoc.chat.entity.ChatMessage;
+import com.knoc.chat.entity.MessageType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.LocalDateTime;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    // 특정 주문에 대해 지정 시각 이후 동일 타입 메시지가 존재하는지 확인
+    boolean existsByReferenceIdAndMessageTypeAndCreatedAtAfter(
+            Long referenceId, MessageType messageType, LocalDateTime threshold);
 }

--- a/src/main/java/com/knoc/order/controller/OrderController.java
+++ b/src/main/java/com/knoc/order/controller/OrderController.java
@@ -1,11 +1,17 @@
 package com.knoc.order.controller;
 
+import com.knoc.global.exception.BusinessException;
+import com.knoc.global.exception.ErrorCode;
+import com.knoc.member.Member;
+import com.knoc.member.MemberRepository;
 import com.knoc.order.dto.OrderRequest;
 import com.knoc.order.dto.OrderResponse;
 import com.knoc.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController // JSON 데이터를 주고받는 API 전용 컨트롤러
@@ -13,12 +19,17 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/orders")
 public class OrderController {
     private final OrderService orderService;
+    private final MemberRepository memberRepository;
 
     @PostMapping("/request")
     @PreAuthorize("hasRole('SENIOR')") // 시니어만 결제 요청 가능
-    public ResponseEntity<OrderResponse> requestOrder(@RequestBody OrderRequest dto, @RequestHeader("Idempotency-Key") String idempotencyKey) {
+    public ResponseEntity<OrderResponse> requestOrder(@AuthenticationPrincipal UserDetails userDetails,
+                                                      @RequestBody OrderRequest dto,
+                                                      @RequestHeader("Idempotency-Key") String idempotencyKey) {
         // 1. 현재 로그인한 시니어 ID를 가져온다.
-        Long seniorId = 1L; // 테스트용 id
+        Member member = memberRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        Long seniorId = member.getId();
 
         // 2. 서비스를 호출하여 주문을 생성하고 응답 DTO를 받는다.
         OrderResponse orderResponse = orderService.createOrderRequest(dto, seniorId, idempotencyKey);
@@ -29,8 +40,12 @@ public class OrderController {
 
     @PostMapping("/{orderId}/pay")
     @PreAuthorize("hasRole('USER')")  // 주니어 결제 가능
-    public ResponseEntity<OrderResponse> requestPay(@PathVariable Long orderId, @RequestHeader("Idempotency-Key") String idempotencyKey) {
-        Long juniorId = 1L; // 테스트용 id
+    public ResponseEntity<OrderResponse> requestPay(@AuthenticationPrincipal UserDetails userDetails,
+                                                    @PathVariable Long orderId,
+                                                    @RequestHeader("Idempotency-Key") String idempotencyKey) {
+        Member member = memberRepository.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        Long juniorId = member.getId();
         OrderResponse orderResponse = orderService.preparePayment(orderId, idempotencyKey, juniorId);
         return ResponseEntity.ok(orderResponse);
     }

--- a/src/main/java/com/knoc/order/controller/TossPaymentController.java
+++ b/src/main/java/com/knoc/order/controller/TossPaymentController.java
@@ -103,18 +103,16 @@ public class TossPaymentController {
             @RequestParam(required = false) String code,
             @RequestParam(required = false) String message,
             @RequestParam(required = false) String orderId) {
-        String msg = message != null ? message : "결제가 취소되었거나 실패했습니다.";
+        String reason = (message == null || message.isBlank()) ? null : message;
         if (code != null && !code.isBlank()) {
-            msg = msg + " (" + code + ")";
+            reason = (reason == null) ? code : reason + " (" + code + ")";
         }
         // 실패/취소도 채팅에 시스템 메시지로 남김
-        orderService.recordPaymentFailure(orderId, msg);
+        orderService.recordPaymentFailure(orderId, reason);
 
         // 토스 리다이렉트 착지 응답은 필요하지만, 결과 화면을 보여주지 않고 채팅방 시스템 메시지로 전달하기 때문에 302로 이동.
         // (채팅 URL이 정해지면 여기 Location("/")만 채팅방 URL로 바꾸면 됨)
-        return ResponseEntity.status(302)
-                .header(HttpHeaders.LOCATION, "/")
-                .build();
+        return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
     }
 
     private String parseTossErrorMessage(String responseBody) {

--- a/src/main/java/com/knoc/order/controller/TossPaymentController.java
+++ b/src/main/java/com/knoc/order/controller/TossPaymentController.java
@@ -36,16 +36,25 @@ public class TossPaymentController {
     @Value("${toss.payments.secret-key:}")
     private String secretKey;
 
+    // Toss 결제창 종료 (브라우저 리다이렉트, ?paymentKey=&orderId=&amount=)
     @GetMapping("/success")
     @ResponseBody
     public ResponseEntity<Void> success(
             @RequestParam String paymentKey,
             @RequestParam String orderId,
-            @RequestParam long amount) {
+            @RequestParam int amount) {
         if (secretKey == null || secretKey.isBlank()) {
             orderService.recordPaymentFailure(orderId, "서버 설정 오류로 결제 결과를 처리하지 못했습니다.");
             // 토스 리다이렉트 착지 응답은 필요하지만, 결과 화면을 보여주지 않고 채팅방 시스템 메시지로 전달하기 때문에 302로 이동.
             // (채팅 URL이 정해지면 여기 Location("/")만 채팅방 URL로 바꾸면 됨)
+            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
+        }
+
+        // Toss confirm 호출 전 사전 금액 검증 (돈 묶이기 전에 차단) + 이미 PAID면 멱등 허용
+        try {
+            orderService.verifyPaymentAmount(orderId, amount);
+        } catch (BusinessException e) {
+            orderService.recordPaymentFailure(orderId, e.getMessage());
             return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
         }
 

--- a/src/main/java/com/knoc/order/dto/OrderResponse.java
+++ b/src/main/java/com/knoc/order/dto/OrderResponse.java
@@ -14,6 +14,9 @@ public class OrderResponse {
     private Long chatRoomId;
     private int amount;
     private OrderStatus orderStatus;
+    // preparePayment()에서도 해당 dto를 반환하기 때문에 시니어 정보가 필요함
+    private String seniorNickname;
+    private String seniorProfileImageUrl;
 
     public static OrderResponse from(Order order) {
         return OrderResponse.builder()
@@ -22,6 +25,8 @@ public class OrderResponse {
                 .chatRoomId(order.getChatRoom().getId())
                 .amount(order.getAmount())
                 .orderStatus(order.getStatus())
+                .seniorNickname(order.getSenior().getNickname())
+                .seniorProfileImageUrl(order.getSenior().getProfileImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -109,9 +109,6 @@ public class OrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
-        // String lockKey = "pay:" + order.getOrderNumber(); // 주문 생성 단계에서의 lockKey와 동일
-        // (같은 주문에 대한 작업을 같은 키로 직렬화)
-
         // 주니어 검증
         if (order.getJunior() == null || order.getJunior().getId() == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
@@ -128,7 +125,7 @@ public class OrderService {
             throw new BusinessException(ErrorCode.ORDER_CANNOT_BE_PAID); // 결제 불가능한 상태
         }
 
-        return OrderResponse.from(order); // 결제 가능한 상태
+        return OrderResponse.from(order); // 결제 가능한 상태(PENDING)면 dto 만들어서 반환
     }
 
     // 토스페이먼츠 결제 승인(confirm) 성공 후 호출

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -26,6 +26,15 @@ import org.springframework.util.StringUtils;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+// 주문/결제 서비스
+// 메서드 순서는 실제 호출 흐름(해피 패스)을 따른다:
+//   1) createOrderRequest     - 시니어가 주문 생성
+//   2) preparePayment         - 주니어가 결제 버튼 클릭 시 사전 검증/조회
+//   3) verifyPaymentAmount    - Toss confirm API 호출 전 사전 금액 검증
+//   4) confirmPayment         - Toss confirm 성공 후 상태 전이 (PENDING -> PAID)
+//   5) markPaid (private)     - confirmPayment 내부 공통 처리 (저장 + 완료 이벤트)
+//   6) recordPaymentFailure   - 실패/취소 경로
+//
 @Slf4j
 @Service
 @Transactional
@@ -106,7 +115,7 @@ public class OrderService {
         if (!StringUtils.hasText(idempotencyKey) || idempotencyKey.trim().length() < 10) {
             throw new BusinessException(ErrorCode.INVALID_IDEMPOTENCY_KEY);
         }
-        if(juniorId == null) {
+        if (juniorId == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
@@ -136,9 +145,49 @@ public class OrderService {
         return OrderResponse.from(order); // 결제 가능한 상태(PENDING)면 dto 만들어서 반환
     }
 
+    // Toss confirm API 호출 전 사전 금액 검증.
+    // "돈이 Toss에 묶이기 전에" 주문 금액과 요청 금액의 일치 여부를 확인하여,
+    // 승인 이후에야 불일치를 발견하는 치명 케이스(환불 필요 상태)를 원천 차단하는 것이 목적.
+    // - 로컬에 주문이 없는 경우(예: 메인 테스트용 TEST-...): confirmPayment 정책과 동일하게 스킵
+    // - 이미 PAID: 중복 호출 대비 멱등 허용
+    // - 불일치: ORDER_PAYMENT_AMOUNT_MISMATCH 예외 + error 로그
+    // NOTE: confirmPayment에도 동일 성격의 사후 재검증이 남아있음. 두 검증은 defense-in-depth로 공존함
+    // (사전: 일반적인 변조/버그 차단 / 사후: Toss 응답 totalAmount가 요청 amount와 달라지는 극희소 케이스 대비)
+    public void verifyPaymentAmount(String tossOrderId, int amount) {
+        // 음수 방어 (쿼리 변조로 음수 전달 가능)
+        if (amount < 0) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        // OrderId가 없거나 빈 값이면 에러
+        if (tossOrderId == null || tossOrderId.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        Optional<Order> found = orderRepository.findByOrderNumber(tossOrderId);
+        if (found.isEmpty()) {
+            return; // 로컬에 없는 주문은 스킵 (confirmPayment 정책과 동일)
+        }
+        Order order = found.get();
+
+        // 이미 PAID면 멱등 허용 (중복 confirm 호출 대비)
+        if (order.getStatus() == OrderStatus.PAID) {
+            return;
+        }
+
+        if (order.getAmount() != amount) {
+            log.error("결제 사전 금액 불일치: orderId={}, orderNumber={}, expected={}, received={}",
+                    order.getId(), order.getOrderNumber(), order.getAmount(), amount);
+            throw new BusinessException(ErrorCode.ORDER_PAYMENT_AMOUNT_MISMATCH);
+        }
+    }
+
     // 토스페이먼츠 결제 승인(confirm) 성공 후 호출
     // tossOrderId는 결제 요청 시 넣은 주문번호로, OrderService의 orderNumber와 같아야 함
     // 로컬에 해당 주문이 없으면(예: 메인 테스트용 TEST-...) Optional.empty() 를 반환
+    // NOTE: verifyPaymentAmount에서 이미 동일한 입력/조회 체크가 수행될 수 있지만,
+    // confirmPayment도 단독 호출 가능한 public 엔트리포인트이므로 방어적으로 재검증/재조회를 수행함
+    // (defense-in-depth, 쿼리 비용은 UNIQUE 인덱스 조회라 무시 가능)
     public Optional<OrderResponse> confirmPayment(String tossOrderId, long confirmedAmount) {
         if (tossOrderId == null || tossOrderId.isBlank()) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
@@ -155,16 +204,53 @@ public class OrderService {
         }
         // SETTLED, CANCELLED 상태는 preparePayment()에서 ORDER_CANNOT_BE_PAID 에러로 이미 걸러짐
 
+        // Toss 승인은 이미 완료된 상태이므로, 여기서 불일치가 잡히면 돈이 묶인 상태다.
+        // verifyPaymentAmount가 사전에 있지만, 이 분기는
+        //   (a) Toss 응답 totalAmount가 우리가 보낸 amount와 다른 극희소 케이스
+        //   (b) confirmPayment가 다른 경로에서 단독 호출된 경우
+        // 를 대비한 최후 방어선이며, 도달 시 즉시 운영 알람이 필요한 상황이다.
+        // TODO: 이 분기 진입 시 자동 환불(Toss cancel API) 트리거 연동
         if (order.getAmount() != confirmedAmount) {
-            throw new BusinessException(ErrorCode.ORDER_PAYMENT_AMOUNT_MISMATCH); // 결제 금액 불일치
+            log.error("결제 사후 금액 불일치(승인 완료 상태): orderId={}, orderNumber={}, expected={}, confirmed={}",
+                    order.getId(), order.getOrderNumber(), order.getAmount(), confirmedAmount);
+            throw new BusinessException(ErrorCode.ORDER_PAYMENT_AMOUNT_MISMATCH);
         }
         return Optional.of(markPaid(order)); // 결제 완료 처리
     }
 
-    // 토스 결제 실패/취소 리다이렉트 후 호출합니다.
-    // 주문이 존재하면 채팅방에 시스템 메시지를 저장합니다.
-    // 주문이 없으면(예: TEST-...) 아무 것도 하지 않습니다.
-    // 주문 상태는 기본적으로 변경하지 않습니다(PENDING 유지).
+    // PG(토스 등) 승인 이후 공통 처리: PENDING -> PAID, 저장, 결제완료 시스템 메시지
+    private OrderResponse markPaid(Order order) {
+        Long orderId = order.getId();
+        order.updateStatus(OrderStatus.PAID);
+
+        // 저장 (낙관적 락 충돌 시: 재조회 후 멱등 성공/충돌 응답)
+        final Order savedOrder;
+        try {
+            savedOrder = orderRepository.saveAndFlush(order);
+        } catch (OptimisticLockingFailureException e) {
+            Order latest = orderRepository.findById(orderId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+            if (latest.getStatus() == OrderStatus.PAID) {
+                return OrderResponse.from(latest); // 이미 결제 처리 완료된 경우 멱등 성공 (200)
+            }
+            throw new BusinessException(ErrorCode.ORDER_PAYMENT_CONFLICT); // 아직 PAID가 아니라면 충돌(409)
+        }
+
+        // 결제 완료 시스템 이벤트 발행
+        eventPublisher.publishEvent(new ChatSystemEvent(
+                savedOrder.getChatRoom().getId(),
+                MessageType.PAYMENT_COMPLETED,
+                null, // 템플릿 사용 → "결제가 성공적으로 처리되었습니다.\n결제 금액은 구매 확정 시까지 Knoc에서 안전하게 보호합니다."
+                savedOrder.getId()
+        ));
+
+        return OrderResponse.from(savedOrder);
+    }
+
+    // 토스 결제 실패/취소 리다이렉트 후 호출
+    // 주문이 존재하면 채팅방에 시스템 메시지를 저장함
+    // 주문이 없으면(예: TEST-...) 아무 것도 하지 않음
+    // 주문 상태는 기본적으로 변경하지 않음(PENDING 유지)
     public void recordPaymentFailure(String tossOrderId, String reason) {
         if (tossOrderId == null || tossOrderId.isBlank()) {
             return; // 토스 fail 콜백에서 orderId가 없을 수 있어 조용히 무시
@@ -191,41 +277,12 @@ public class OrderService {
         // 결제 실패에 대한 로그
         log.warn("결제 실패 처리: orderId={}, reason={}", order.getId(), reason);
 
+        // 결제 실패 시스템 이벤트 발행
         eventPublisher.publishEvent(new ChatSystemEvent(
                 order.getChatRoom().getId(),
                 MessageType.PAYMENT_FAILED,
                 null, // 템플릿 사용 → "결제가 실패하거나 취소되었습니다. 다시 시도해주세요."
                 order.getId()
         ));
-    }
-
-    // PG(토스 등) 승인 이후 공통 처리: PENDING -> PAID, 저장, 결제완료 시스템 메시지
-    private OrderResponse markPaid(Order order) {
-        Long orderId = order.getId();
-        order.updateStatus(OrderStatus.PAID);
-
-        // 저장 (낙관적 락 충돌 시: 재조회 후 멱등 성공/충돌 응답)
-        final Order savedOrder;
-        try {
-            savedOrder = orderRepository.saveAndFlush(order);
-        } catch (OptimisticLockingFailureException e) {
-            Order latest = orderRepository.findById(orderId)
-                    .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
-            if (latest.getStatus() == OrderStatus.PAID) {
-                return OrderResponse.from(latest); // 이미 결제 처리 완료된 경우 멱등 성공 (200)
-            }
-            throw new BusinessException(ErrorCode.ORDER_PAYMENT_CONFLICT); // 아직 PAID가 아니라면 충돌(409)
-        }
-
-        // 결제 완료 메시지 생성 및 시스템 이벤트 발행
-        String customMessage = MessageType.PAYMENT_COMPLETED.getTemplate();
-        eventPublisher.publishEvent(new ChatSystemEvent(
-                savedOrder.getChatRoom().getId(),
-                MessageType.PAYMENT_COMPLETED,
-                customMessage,
-                savedOrder.getId()
-        ));
-
-        return OrderResponse.from(savedOrder);
     }
 }

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -201,8 +201,10 @@ public class OrderService {
         // 이미 PAID면 금액검증/마크 없이 멱등 반환
         if (order.getStatus() == OrderStatus.PAID) {
             return Optional.of(OrderResponse.from(order));
+        } // SETTLED, CANCELLED 상태는 결제 불가능한 상태이므로 에러
+        else if (order.getStatus() != OrderStatus.PENDING) {
+            throw new BusinessException(ErrorCode.ORDER_CANNOT_BE_PAID);
         }
-        // SETTLED, CANCELLED 상태는 preparePayment()에서 ORDER_CANNOT_BE_PAID 에러로 이미 걸러짐
 
         // 이 분기는:
         //   (a) Toss 응답 totalAmount가 우리가 보낸 amount와 다른 극희소 케이스

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -3,6 +3,7 @@ package com.knoc.order.service;
 import com.knoc.chat.entity.ChatRoom;
 import com.knoc.chat.entity.ChatSystemEvent;
 import com.knoc.chat.entity.MessageType;
+import com.knoc.chat.repository.ChatMessageRepository;
 import com.knoc.chat.repository.ChatRoomRepository;
 import com.knoc.global.exception.BusinessException;
 import com.knoc.global.exception.ErrorCode;
@@ -14,6 +15,7 @@ import com.knoc.order.entity.Order;
 import com.knoc.order.entity.OrderStatus;
 import com.knoc.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -21,8 +23,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -31,6 +35,10 @@ public class OrderService {
     private final ChatRoomRepository chatRoomRepository;
     private final MemberRepository memberRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final ChatMessageRepository chatMessageRepository;
+
+    // 결제 실패 메시지 중복 발행 방지를 위한 쿨다운 (30초)
+    private static final long FAILURE_MESSAGE_COOLDOWN_SECONDS = 30L;
 
     @Transactional
     public OrderResponse createOrderRequest(OrderRequest dto, Long seniorId, String idempotencyKey) {
@@ -167,14 +175,26 @@ public class OrderService {
         }
         Order order = found.get();
 
-        String customMessage = (reason == null || reason.isBlank())
-                ? MessageType.PAYMENT_FAILED.getTemplate()
-                : MessageType.PAYMENT_FAILED.getTemplate() + "\n사유: " + reason;
+        // 방어선1: 이미 결제 성공/정산된 주문이면 실패 메시지 발행 안 함
+        // (결제 성공 직후 뒤늦게 fail 콜백이 도달하는 엣지 케이스 방어)
+        if (order.getStatus() == OrderStatus.PAID || order.getStatus() == OrderStatus.SETTLED) {
+            return;
+        }
+
+        // 방어선2: 최근 30초 이내 동일 주문의 실패 메시지가 이미 있으면 스킵
+        LocalDateTime threshold = LocalDateTime.now().minusSeconds(FAILURE_MESSAGE_COOLDOWN_SECONDS);
+        if (chatMessageRepository.existsByReferenceIdAndMessageTypeAndCreatedAtAfter(
+                order.getId(), MessageType.PAYMENT_FAILED, threshold)) {
+            return;
+        }
+
+        // 결제 실패에 대한 로그
+        log.warn("결제 실패 처리: orderId={}, reason={}", order.getId(), reason);
 
         eventPublisher.publishEvent(new ChatSystemEvent(
                 order.getChatRoom().getId(),
                 MessageType.PAYMENT_FAILED,
-                customMessage,
+                null, // 템플릿 사용 → "결제가 실패하거나 취소되었습니다. 다시 시도해주세요."
                 order.getId()
         ));
     }

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -140,6 +140,13 @@ public class OrderService {
             return Optional.empty();
         }
         Order order = found.get();
+
+        // 이미 PAID면 금액검증/마크 없이 멱등 반환
+        if (order.getStatus() == OrderStatus.PAID) {
+            return Optional.of(OrderResponse.from(order));
+        }
+        // SETTLED, CANCELLED 상태는 preparePayment()에서 ORDER_CANNOT_BE_PAID 에러로 이미 걸러짐
+
         if (order.getAmount() != confirmedAmount) {
             throw new BusinessException(ErrorCode.ORDER_PAYMENT_AMOUNT_MISMATCH); // 결제 금액 불일치
         }
@@ -175,15 +182,8 @@ public class OrderService {
     // PG(토스 등) 승인 이후 공통 처리: PENDING -> PAID, 저장, 결제완료 시스템 메시지
     private OrderResponse markPaid(Order order) {
         Long orderId = order.getId();
+        order.updateStatus(OrderStatus.PAID);
 
-        // 상태 분기
-        if (order.getStatus() == OrderStatus.PAID) {
-            return OrderResponse.from(order); // 결제 완료 메시지 중복 방지
-        } else if (order.getStatus() == OrderStatus.PENDING) {
-            order.updateStatus(OrderStatus.PAID);
-        } else { // 그 외의 상태(SETTLED, CANCELLED)는 에러
-            throw new BusinessException(ErrorCode.ORDER_CANNOT_BE_PAID);
-        }
         // 저장 (낙관적 락 충돌 시: 재조회 후 멱등 성공/충돌 응답)
         final Order savedOrder;
         try {

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -204,12 +204,14 @@ public class OrderService {
         }
         // SETTLED, CANCELLED 상태는 preparePayment()에서 ORDER_CANNOT_BE_PAID 에러로 이미 걸러짐
 
-        // Toss 승인은 이미 완료된 상태이므로, 여기서 불일치가 잡히면 돈이 묶인 상태다.
-        // verifyPaymentAmount가 사전에 있지만, 이 분기는
+        // 이 분기는:
         //   (a) Toss 응답 totalAmount가 우리가 보낸 amount와 다른 극희소 케이스
         //   (b) confirmPayment가 다른 경로에서 단독 호출된 경우
-        // 를 대비한 최후 방어선이며, 도달 시 즉시 운영 알람이 필요한 상황이다.
-        // TODO: 이 분기 진입 시 자동 환불(Toss cancel API) 트리거 연동
+        // 를 잡아내기 위한 최후 방어선. 도달 시 에러 로그 + 예외로 상위에 알림.
+        //
+        // 본 프로젝트는 Toss 테스트 키로만 동작하므로 실제 환불 API 호출은 불필요함
+        // 운영 전환 시에는 이 분기에서 돈이 묶이는 상황이므로
+        // POST https://api.tosspayments.com/v1/payments/{paymentKey}/cancel 연동 필요함
         if (order.getAmount() != confirmedAmount) {
             log.error("결제 사후 금액 불일치(승인 완료 상태): orderId={}, orderNumber={}, expected={}, confirmed={}",
                     order.getId(), order.getOrderNumber(), order.getAmount(), confirmedAmount);

--- a/src/test/java/com/knoc/order/service/OrderServiceTest.java
+++ b/src/test/java/com/knoc/order/service/OrderServiceTest.java
@@ -23,7 +23,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -262,7 +264,6 @@ class OrderServiceTest {
 
         ChatSystemEvent capturedEvent = eventCaptor.getValue();
         assertThat(capturedEvent.type()).isEqualTo(MessageType.PAYMENT_COMPLETED);
-        assertThat(capturedEvent.customContent()).contains("결제가 성공적으로 처리되었습니다.");
     }
 
     @Test
@@ -365,5 +366,372 @@ class OrderServiceTest {
         assertThat(response.getOrderNumber()).isEqualTo(orderNumber);
         assertThat(response.getAmount()).isEqualTo(50000);
         verify(orderRepository, times(2)).findByOrderNumber(orderNumber); // 처음 + catch문 재조회
+    }
+
+    // ============================================================
+    // A. confirmPayment 승인 멱등성
+    // ============================================================
+
+    @Test
+    @DisplayName("결제 승인 멱등: 이미 PAID인 주문에 confirm 재호출되면 저장/이벤트 없이 기존 응답 반환")
+    void confirmPayment_Idempotent_WhenAlreadyPaid() {
+        // given
+        String tossOrderId = "ORD-PAID";
+        long confirmedAmount = 50000L;
+
+        Order order = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(mock(ChatRoom.class))
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount((int) confirmedAmount)
+                .build();
+        order.updateStatus(OrderStatus.PAID);
+
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.of(order));
+
+        // when
+        Optional<OrderResponse> responseOpt = orderService.confirmPayment(tossOrderId, confirmedAmount);
+
+        // then
+        assertThat(responseOpt).isPresent();
+        assertThat(responseOpt.get().getOrderStatus()).isEqualTo(OrderStatus.PAID);
+        verify(orderRepository, never()).saveAndFlush(any(Order.class));
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("결제 승인: 로컬에 없는 주문(예: TEST-...)은 Optional.empty() 반환")
+    void confirmPayment_Empty_WhenOrderNotFound() {
+        // given
+        String tossOrderId = "TEST-UNKNOWN";
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.empty());
+
+        // when
+        Optional<OrderResponse> responseOpt = orderService.confirmPayment(tossOrderId, 10000L);
+
+        // then
+        assertThat(responseOpt).isEmpty();
+        verify(orderRepository, never()).saveAndFlush(any(Order.class));
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("결제 승인 멱등: 낙관적 락 충돌 후 재조회 시 PAID면 기존 응답 반환(이벤트 미발행)")
+    void confirmPayment_Recovers_WhenOptimisticLockAndAlreadyPaidByOtherTx() {
+        // given
+        String tossOrderId = "ORD-LOCK";
+        long confirmedAmount = 50000L;
+        Long orderId = 200L;
+
+        Order current = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(mock(ChatRoom.class))
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount((int) confirmedAmount)
+                .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(current, "id", orderId);
+
+        Order latestPaid = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(mock(ChatRoom.class))
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount((int) confirmedAmount)
+                .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(latestPaid, "id", orderId);
+        latestPaid.updateStatus(OrderStatus.PAID);
+
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.of(current));
+        given(orderRepository.saveAndFlush(any(Order.class)))
+                .willThrow(new OptimisticLockingFailureException("conflict"));
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(latestPaid));
+
+        // when
+        Optional<OrderResponse> responseOpt = orderService.confirmPayment(tossOrderId, confirmedAmount);
+
+        // then
+        assertThat(responseOpt).isPresent();
+        assertThat(responseOpt.get().getOrderStatus()).isEqualTo(OrderStatus.PAID);
+        // 충돌 후 재조회 경로에선 결제완료 이벤트가 중복 발행되지 않아야 함
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("결제 승인 충돌: 낙관적 락 충돌 후 재조회 시 여전히 PAID가 아니면 ORDER_PAYMENT_CONFLICT(409) 예외")
+    void confirmPayment_Throws_WhenOptimisticLockAndStillNotPaid() {
+        // given
+        String tossOrderId = "ORD-LOCK2";
+        long confirmedAmount = 50000L;
+        Long orderId = 201L;
+
+        Order current = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(mock(ChatRoom.class))
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount((int) confirmedAmount)
+                .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(current, "id", orderId);
+
+        Order latestStillPending = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(mock(ChatRoom.class))
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount((int) confirmedAmount)
+                .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(latestStillPending, "id", orderId);
+
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.of(current));
+        given(orderRepository.saveAndFlush(any(Order.class)))
+                .willThrow(new OptimisticLockingFailureException("conflict"));
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(latestStillPending));
+
+        // when & then
+        assertThatThrownBy(() -> orderService.confirmPayment(tossOrderId, confirmedAmount))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.ORDER_PAYMENT_CONFLICT.getMessage());
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("결제 승인 사후 금액 불일치: ORDER_PAYMENT_AMOUNT_MISMATCH 예외 + 저장/이벤트 없음")
+    void confirmPayment_Throws_OnAmountMismatch() {
+        // given
+        String tossOrderId = "ORD-AMT";
+        int orderAmount = 50000;
+        long confirmedAmount = 10000L; // 불일치
+
+        Order order = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(mock(ChatRoom.class))
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount(orderAmount)
+                .build();
+
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderService.confirmPayment(tossOrderId, confirmedAmount))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.ORDER_PAYMENT_AMOUNT_MISMATCH.getMessage());
+
+        verify(orderRepository, never()).saveAndFlush(any(Order.class));
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    // ============================================================
+    // B. verifyPaymentAmount 사전 금액 검증
+    // ============================================================
+
+    @Test
+    @DisplayName("사전 금액 검증: 음수 amount면 INVALID_INPUT_VALUE 예외(주문 조회 이전에 차단)")
+    void verifyPaymentAmount_Throws_OnNegativeAmount() {
+        // when & then
+        assertThatThrownBy(() -> orderService.verifyPaymentAmount("ORD-NEG", -1))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+
+        // 음수면 조회까지 가지 않아야 함
+        verify(orderRepository, never()).findByOrderNumber(any());
+    }
+
+    @Test
+    @DisplayName("사전 금액 검증 멱등: 이미 PAID면 예외 없이 조용히 리턴(금액 달라도 무시)")
+    void verifyPaymentAmount_NoOp_WhenAlreadyPaid() {
+        // given
+        String tossOrderId = "ORD-PAID-VERIFY";
+        int amount = 50000;
+
+        Order order = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(mock(ChatRoom.class))
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount(amount)
+                .build();
+        order.updateStatus(OrderStatus.PAID);
+
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.of(order));
+
+        // when & then (예외가 나지 않아야 함: PAID면 금액 비교 전에 리턴)
+        orderService.verifyPaymentAmount(tossOrderId, amount + 999);
+    }
+
+    @Test
+    @DisplayName("사전 금액 검증: 로컬에 없는 주문이면 조용히 리턴(confirmPayment와 동일 정책)")
+    void verifyPaymentAmount_NoOp_WhenOrderNotFound() {
+        // given
+        given(orderRepository.findByOrderNumber("TEST-UNKNOWN")).willReturn(Optional.empty());
+
+        // when & then (예외 없음)
+        orderService.verifyPaymentAmount("TEST-UNKNOWN", 50000);
+    }
+
+    @Test
+    @DisplayName("사전 금액 검증: 주문 금액과 불일치 시 ORDER_PAYMENT_AMOUNT_MISMATCH 예외")
+    void verifyPaymentAmount_Throws_OnAmountMismatch() {
+        // given
+        String tossOrderId = "ORD-AMT-PRE";
+
+        Order order = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(mock(ChatRoom.class))
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount(50000)
+                .build();
+
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> orderService.verifyPaymentAmount(tossOrderId, 10000))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.ORDER_PAYMENT_AMOUNT_MISMATCH.getMessage());
+    }
+
+    // ============================================================
+    // C. recordPaymentFailure 실패 멱등성
+    // ============================================================
+
+    @Test
+    @DisplayName("결제 실패 멱등: 이미 PAID 주문이면 실패 메시지 발행 안 함(뒤늦은 fail 콜백 방어)")
+    void recordPaymentFailure_Skips_WhenAlreadyPaid() {
+        // given
+        String tossOrderId = "ORD-FAIL-PAID";
+
+        Order order = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(mock(ChatRoom.class))
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount(50000)
+                .build();
+        order.updateStatus(OrderStatus.PAID);
+
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.of(order));
+
+        // when
+        orderService.recordPaymentFailure(tossOrderId, "뒤늦게 도달한 실패 콜백");
+
+        // then (방어선1: 상태 체크에서 먼저 걸러져 쿨다운 조회까지 가지 않음)
+        verify(eventPublisher, never()).publishEvent(any());
+        verify(chatMessageRepository, never())
+                .existsByReferenceIdAndMessageTypeAndCreatedAtAfter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("결제 실패 멱등: 이미 SETTLED 주문이면 실패 메시지 발행 안 함")
+    void recordPaymentFailure_Skips_WhenAlreadySettled() {
+        // given
+        String tossOrderId = "ORD-FAIL-SETTLED";
+
+        Order order = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(mock(ChatRoom.class))
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount(50000)
+                .build();
+        // PENDING -> PAID -> SETTLED (Order.validateTransition 순서에 맞춰 두 단계로 전이)
+        order.updateStatus(OrderStatus.PAID);
+        order.updateStatus(OrderStatus.SETTLED);
+
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.of(order));
+
+        // when
+        orderService.recordPaymentFailure(tossOrderId, "이미 정산됨");
+
+        // then
+        verify(eventPublisher, never()).publishEvent(any());
+        verify(chatMessageRepository, never())
+                .existsByReferenceIdAndMessageTypeAndCreatedAtAfter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("결제 실패 멱등: 최근 30초 내 PAYMENT_FAILED 이력이 있으면 중복 발행 스킵(쿨다운)")
+    void recordPaymentFailure_Skips_WhenRecentFailureExists() {
+        // given
+        String tossOrderId = "ORD-FAIL-COOLDOWN";
+        Long orderId = 300L;
+
+        Order order = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(mock(ChatRoom.class))
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount(50000)
+                .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(order, "id", orderId);
+        // status = PENDING (기본값)
+
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.of(order));
+        given(chatMessageRepository.existsByReferenceIdAndMessageTypeAndCreatedAtAfter(
+                eq(orderId), eq(MessageType.PAYMENT_FAILED), any(LocalDateTime.class)))
+                .willReturn(true);
+
+        // when
+        orderService.recordPaymentFailure(tossOrderId, "재시도 콜백");
+
+        // then
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("결제 실패 정상 경로: PENDING + 쿨다운 없음 → PAYMENT_FAILED 이벤트 1회(템플릿) 발행")
+    void recordPaymentFailure_Publishes_WhenEligible() {
+        // given
+        String tossOrderId = "ORD-FAIL-OK";
+        Long orderId = 301L;
+        Long chatRoomId = 10L;
+
+        ChatRoom chatRoom = mock(ChatRoom.class);
+        given(chatRoom.getId()).willReturn(chatRoomId);
+
+        Order order = Order.builder()
+                .orderNumber(tossOrderId)
+                .chatRoom(chatRoom)
+                .junior(mock(Member.class))
+                .senior(mock(Member.class))
+                .amount(50000)
+                .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(order, "id", orderId);
+
+        given(orderRepository.findByOrderNumber(tossOrderId)).willReturn(Optional.of(order));
+        given(chatMessageRepository.existsByReferenceIdAndMessageTypeAndCreatedAtAfter(
+                eq(orderId), eq(MessageType.PAYMENT_FAILED), any(LocalDateTime.class)))
+                .willReturn(false);
+
+        // when
+        orderService.recordPaymentFailure(tossOrderId, "카드 한도 초과");
+
+        // then: 이벤트 1회, 템플릿 사용(customContent == null), referenceId 일치
+        ArgumentCaptor<ChatSystemEvent> captor = ArgumentCaptor.forClass(ChatSystemEvent.class);
+        verify(eventPublisher, times(1)).publishEvent(captor.capture());
+
+        ChatSystemEvent event = captor.getValue();
+        assertThat(event.type()).isEqualTo(MessageType.PAYMENT_FAILED);
+        assertThat(event.customContent()).isNull();
+        assertThat(event.referenceId()).isEqualTo(orderId);
+        assertThat(event.roomId()).isEqualTo(chatRoomId);
+    }
+
+    @Test
+    @DisplayName("결제 실패: 로컬에 없는 주문이면 아무 것도 하지 않음(상태/메시지/로그 영향 없음)")
+    void recordPaymentFailure_NoOp_WhenOrderNotFound() {
+        // given
+        given(orderRepository.findByOrderNumber("TEST-UNKNOWN")).willReturn(Optional.empty());
+
+        // when
+        orderService.recordPaymentFailure("TEST-UNKNOWN", "사유");
+
+        // then
+        verify(eventPublisher, never()).publishEvent(any());
+        verify(chatMessageRepository, never())
+                .existsByReferenceIdAndMessageTypeAndCreatedAtAfter(any(), any(), any());
     }
 }

--- a/src/test/java/com/knoc/order/service/OrderServiceTest.java
+++ b/src/test/java/com/knoc/order/service/OrderServiceTest.java
@@ -3,6 +3,7 @@ package com.knoc.order.service;
 import com.knoc.chat.entity.ChatRoom;
 import com.knoc.chat.entity.ChatSystemEvent;
 import com.knoc.chat.entity.MessageType;
+import com.knoc.chat.repository.ChatMessageRepository;
 import com.knoc.chat.repository.ChatRoomRepository;
 import com.knoc.global.exception.BusinessException;
 import com.knoc.global.exception.ErrorCode;
@@ -49,6 +50,9 @@ class OrderServiceTest {
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
 
     @Test
     @DisplayName("결제 요청 성공: 정상적인 데이터가 입력되면 주문이 PENDING 상태로 생성된다.")


### PR DESCRIPTION
## 🔎 What

결제 승인 단계의 멱등성을 보장한다. 
주문 생성 단계(#63)가 클라이언트 멱등키 + `orderNumber` UNIQUE로 중복을 막았다면, 이 PR은 **주문 상태 전이(PENDING → PAID)** 와 **@Version 낙관적 락**을 기준으로 토스 리다이렉트 재진입·네트워크 재시도·동시 요청에 의한 중복 호출을 상태 기반으로 안전하게 수습한다.

### 멱등성 보장
- 이미 `PAID`인 주문에 `confirm` 재호출 시 상태 변경/메시지 발행 없이 기존 응답 반환
- 동시 `confirm` 요청의 낙관적 락 충돌을 재조회로 안전 복구 (PAID면 멱등 성공, 그 외는 `ORDER_PAYMENT_CONFLICT` 409)
- `SETTLED`/`CANCELLED` 상태 결제 호출 차단 (`preparePayment`에서 `ORDER_CANNOT_BE_PAID`로 일원화)
- 결제 실패/취소 콜백 중복 시 시스템 메시지 중복 발행 방지 (상태 가드 + 최근 30초 이내 동일 이력 쿨다운)
- 금액 불일치 검증 경로 점검: 토스 `confirm` 호출 전 사전 차단(`verifyPaymentAmount`) 신설 + 사후 재검증 로그/주석 강화
- OrderService의 메서드를 호출 흐름에 맞게 재정렬 (createOrderRequest -> preparePayment -> verifyPaymentAmount -> confirmPayment -> markPaid(private) -> recordPaymentFailure)

### 테스트
- `OrderServiceTest`에 결제 승인·실패 멱등성 단위 테스트 14개 추가

### 추가 작업
멱등성과 직접 관련은 없지만 백엔드 정리 차원에서 이 PR에 함께 포함했습니다.
- 하드코딩된 `seniorId`/`juniorId` 제거 → `@AuthenticationPrincipal`에서 조회
- `OrderResponse`에 시니어 닉네임/프로필 이미지 필드 추가 (결제 모달 UI용 선작업)

## 🔗 Issue

- Closes: #67 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?

