### PR TITLE
refactor: Toss 결제 / Order 도메인 코드 리팩토링 및 운영 안정화

### DIFF
--- a/src/main/java/com/knoc/global/config/TossPaymentConfig.java
+++ b/src/main/java/com/knoc/global/config/TossPaymentConfig.java
@@ -1,0 +1,46 @@
+package com.knoc.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+
+// 토스페이먼츠 REST API 호출 전용 RestClient 설정
+// - baseUrl: application.properties의 toss.payments.base-url 사용
+// - connect/read 타임아웃: 토스가 느리거나 멈췄을 때 요청 스레드가 무한 블록되는 것을 방지
+// - Basic 인증 헤더(시크릿 키): 빈 생성 시 1회 조립하여 defaultHeader로 자동 주입
+//   → 컨트롤러에서 더 이상 헤더를 수동으로 만들 필요 없음
+@Configuration
+public class TossPaymentConfig {
+
+    @Bean
+    public RestClient tossRestClient(
+            @Value("${toss.payments.base-url:https://api.tosspayments.com}") String baseUrl,
+            @Value("${toss.payments.secret-key:}") String secretKey,
+            @Value("${toss.payments.connect-timeout:3s}") Duration connectTimeout,
+            @Value("${toss.payments.read-timeout:10s}") Duration readTimeout) {
+
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(connectTimeout); // Toss 서버와 TCP 연결 자체가 3초 내에 안 맺어지면 실패 처리
+        factory.setReadTimeout(readTimeout); // Toss 서버에서 응답이 10초 내에 안 오면 실패 처리
+
+        RestClient.Builder builder = RestClient.builder()
+                .baseUrl(baseUrl)
+                .requestFactory(factory);
+
+        // 시크릿 키가 설정돼 있을 때만 인증 헤더 주입 (미설정 환경에서도 애플리케이션 기동은 허용)
+        if (secretKey != null && !secretKey.isBlank()) {
+            String authHeader = "Basic " + Base64.getEncoder()
+                    .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+            builder.defaultHeader(HttpHeaders.AUTHORIZATION, authHeader);
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/knoc/global/exception/ErrorCode.java
+++ b/src/main/java/com/knoc/global/exception/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode {
     ORDER_PAYMENT_CONFLICT(409, "동시에 결제가 시도되어 처리에 실패했습니다. 다시 시도해주세요."),
     ORDER_PAYMENT_AMOUNT_MISMATCH(400, "결제 금액이 주문 금액과 일치하지 않습니다."),
     INVALID_IDEMPOTENCY_KEY(400, "유효하지 않은 멱등성 키입니다."),
+    ORDER_INVALID_AMOUNT(400, "유효하지 않은 결제 금액입니다."),
+    ORDER_INVALID_ORDER_NUMBER(400, "유효하지 않은 주문번호입니다."),
 
     // 리뷰 관련 (Review)
     REVIEW_ALREADY_EXISTS(409, "이미 해당 주문에 대한 후기가 존재합니다."),

--- a/src/main/java/com/knoc/order/controller/OrderController.java
+++ b/src/main/java/com/knoc/order/controller/OrderController.java
@@ -46,12 +46,11 @@ public class OrderController {
     @PostMapping("/{orderId}/pay")
     @PreAuthorize("hasRole('USER')")  // 주니어 결제 가능
     public ResponseEntity<OrderResponse> requestPay(@AuthenticationPrincipal UserDetails userDetails,
-                                                    @PathVariable Long orderId,
-                                                    @RequestHeader("Idempotency-Key") String idempotencyKey) {
+                                                    @PathVariable Long orderId) {
         Member member = memberRepository.findByEmail(userDetails.getUsername())
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
         Long juniorId = member.getId();
-        OrderResponse orderResponse = orderService.preparePayment(orderId, idempotencyKey, juniorId);
+        OrderResponse orderResponse = orderService.preparePayment(orderId, juniorId);
         return ResponseEntity.ok(orderResponse);
     }
 }

--- a/src/main/java/com/knoc/order/controller/TossPaymentController.java
+++ b/src/main/java/com/knoc/order/controller/TossPaymentController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -51,6 +52,14 @@ public class TossPaymentController {
             @RequestParam int amount) {
         // 다시 돌아갈 채팅창 URL
         String chatURL = redirectToChat(orderId);
+
+        // 파라미터 최소 검증: 잘못된 값은 Toss API/DB 조회 전에 차단
+        // amount가 0이어도 검증 실패인 이유: Toss Payments API는 0원 결제를 지원하지 않음
+        if (!StringUtils.hasText(paymentKey) || !StringUtils.hasText(orderId) || amount <= 0) {
+            log.warn("Toss success 파라미터 검증 실패: orderId={}, amount={}", orderId, amount);
+            orderService.recordPaymentFailure(orderId, null);
+            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
+        }
 
         if (secretKey == null || secretKey.isBlank()) {
             orderService.recordPaymentFailure(orderId, "서버 설정 오류로 결제 결과를 처리하지 못했습니다.");
@@ -127,6 +136,7 @@ public class TossPaymentController {
         return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
     }
 
+    // Toss 콜백 후 돌아갈 채팅방 URL 계산 (주문 조회 실패 시 "/"으로 폴백)
     private String redirectToChat(String tossOrderId) {
         if (tossOrderId == null || tossOrderId.isBlank()) {
             return "/";

--- a/src/main/java/com/knoc/order/controller/TossPaymentController.java
+++ b/src/main/java/com/knoc/order/controller/TossPaymentController.java
@@ -18,14 +18,14 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
 // 토스페이먼츠 테스트 결제:
 // - 결제 인증 성공 리다이렉트 후, 서버에서 결제 승인(confirm) API를 호출합니다.
 // - 시크릿 키는 서버에서만 사용합니다(브라우저로 내려가면 안 됨).
+// - 실제 HTTP 호출은 `TossPaymentConfig#tossRestClient`에서 생성된 공용 빈을 사용합니다.
+//   (baseUrl, 타임아웃, Basic 인증 헤더가 자동 구성되어 있음)
 @Controller
 @RequestMapping("/orders/payment/toss")
 @RequiredArgsConstructor
@@ -34,7 +34,9 @@ public class TossPaymentController {
     private final ObjectMapper objectMapper;
     private final OrderService orderService;
     private final OrderRepository orderRepository;
+    private final RestClient tossRestClient;
 
+    // 시크릿 키 설정 여부 가드용으로만 사용 (실제 인증 헤더는 tossRestClient에서 자동 주입)
     @Value("${toss.payments.secret-key:}")
     private String secretKey;
 
@@ -62,20 +64,15 @@ public class TossPaymentController {
             return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
         }
 
-        // Basic 인증: {secretKey}: 를 Base64 인코딩
-        String authHeader = "Basic " + Base64.getEncoder()
-                .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
-
         Map<String, Object> body = new HashMap<>();
         body.put("paymentKey", paymentKey);
         body.put("orderId", orderId);
         body.put("amount", amount);
 
         try {
-            String json = RestClient.create()
+            String json = tossRestClient
                     .post()
-                    .uri("https://api.tosspayments.com/v1/payments/confirm") // <- 토스 서버로 승인 요청
-                    .header(HttpHeaders.AUTHORIZATION, authHeader)
+                    .uri("/v1/payments/confirm") // <- 토스 서버로 승인 요청 (baseUrl은 빈에서 설정)
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(body)
                     .retrieve()

--- a/src/main/java/com/knoc/order/controller/TossPaymentController.java
+++ b/src/main/java/com/knoc/order/controller/TossPaymentController.java
@@ -13,10 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 
@@ -29,7 +26,7 @@ import java.util.Map;
 // - 실제 HTTP 호출은 `TossPaymentConfig#tossRestClient`에서 생성된 공용 빈을 사용합니다.
 //   (baseUrl, 타임아웃, Basic 인증 헤더가 자동 구성되어 있음)
 @Slf4j
-@Controller
+@RestController
 @RequestMapping("/orders/payment/toss")
 @RequiredArgsConstructor
 public class TossPaymentController {
@@ -45,7 +42,6 @@ public class TossPaymentController {
 
     // Toss 결제창 종료 (브라우저 리다이렉트, ?paymentKey=&orderId=&amount=)
     @GetMapping("/success")
-    @ResponseBody
     public ResponseEntity<Void> success(
             @RequestParam String paymentKey,
             @RequestParam String orderId,
@@ -120,7 +116,6 @@ public class TossPaymentController {
     }
 
     @GetMapping("/fail")
-    @ResponseBody
     public ResponseEntity<Void> fail(
             @RequestParam(required = false) String code,
             @RequestParam(required = false) String message,

--- a/src/main/java/com/knoc/order/controller/TossPaymentController.java
+++ b/src/main/java/com/knoc/order/controller/TossPaymentController.java
@@ -6,6 +6,7 @@ import com.knoc.global.exception.BusinessException;
 import com.knoc.order.repository.OrderRepository;
 import com.knoc.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpHeaders;
@@ -26,6 +27,7 @@ import java.util.Map;
 // - 시크릿 키는 서버에서만 사용합니다(브라우저로 내려가면 안 됨).
 // - 실제 HTTP 호출은 `TossPaymentConfig#tossRestClient`에서 생성된 공용 빈을 사용합니다.
 //   (baseUrl, 타임아웃, Basic 인증 헤더가 자동 구성되어 있음)
+@Slf4j
 @Controller
 @RequestMapping("/orders/payment/toss")
 @RequiredArgsConstructor
@@ -93,15 +95,17 @@ public class TossPaymentController {
                     .header(HttpHeaders.LOCATION, chatURL)
                     .build();
         } catch (RestClientResponseException e) {
-            orderService.recordPaymentFailure(orderId,
-                    parseTossErrorMessage(e.getResponseBodyAsString()));
+            log.warn("Toss 결제 승인 실패 응답: orderId={}, body={}", orderId, e.getResponseBodyAsString());
+            orderService.recordPaymentFailure(orderId, null); // null -> MessageType.PAYMENT_FAILED 기본 템플릿
             return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
         } catch (BusinessException e) {
             // confirm은 성공했는데 DB 반영이 실패한 케이스도 채팅 메시지로 남김
+            log.warn("결제 DB 반영 실패: orderId={}, code={}", orderId, e.getMessage());
             orderService.recordPaymentFailure(orderId, e.getMessage());
             return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
         } catch (Exception e) {
-            orderService.recordPaymentFailure(orderId, e.getMessage());
+            log.warn("Toss confirm 처리 중 예기치 못한 오류: orderId={}", orderId, e);
+            orderService.recordPaymentFailure(orderId, null);
             return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
         }
     }
@@ -115,31 +119,12 @@ public class TossPaymentController {
         // 다시 돌아갈 채팅창 URL
         String chatURL = redirectToChat(orderId);
 
-        String reason = (message == null || message.isBlank()) ? null : message;
-        if (code != null && !code.isBlank()) {
-            reason = (reason == null) ? code : reason + " (" + code + ")";
-        }
         // 실패/취소도 채팅에 시스템 메시지로 남김
-        orderService.recordPaymentFailure(orderId, reason);
+        log.warn("Toss 결제 실패 콜백: orderId={}, code={}, message={}", orderId, code, message);
+        orderService.recordPaymentFailure(orderId, null);
 
         // 토스 리다이렉트 착지 응답은 필요하지만, 결과 화면을 보여주지 않고 채팅방 시스템 메시지로 전달하기 때문에 302로 이동.
         return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
-    }
-
-    private String parseTossErrorMessage(String responseBody) {
-        if (responseBody == null || responseBody.isBlank()) {
-            return "결제 승인 요청이 거절되었습니다.";
-        }
-        try {
-            JsonNode n = objectMapper.readTree(responseBody);
-            String msg = n.path("message").asText(null);
-            if (msg != null && !msg.isBlank()) {
-                return msg;
-            }
-        } catch (Exception ignored) {
-            // 파싱 실패 시 원문 반환
-        }
-        return responseBody;
     }
 
     private String redirectToChat(String tossOrderId) {

--- a/src/main/java/com/knoc/order/controller/TossPaymentController.java
+++ b/src/main/java/com/knoc/order/controller/TossPaymentController.java
@@ -138,7 +138,7 @@ public class TossPaymentController {
 
     // Toss 콜백 후 돌아갈 채팅방 URL 계산 (주문 조회 실패 시 "/"으로 폴백)
     private String redirectToChat(String tossOrderId) {
-        if (tossOrderId == null || tossOrderId.isBlank()) {
+        if (!StringUtils.hasText(tossOrderId)) {
             return "/";
         }
         return orderRepository.findByOrderNumber(tossOrderId)

--- a/src/main/java/com/knoc/order/controller/TossPaymentController.java
+++ b/src/main/java/com/knoc/order/controller/TossPaymentController.java
@@ -3,6 +3,7 @@ package com.knoc.order.controller;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.knoc.global.exception.BusinessException;
+import com.knoc.order.repository.OrderRepository;
 import com.knoc.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,6 +33,7 @@ public class TossPaymentController {
 
     private final ObjectMapper objectMapper;
     private final OrderService orderService;
+    private final OrderRepository orderRepository;
 
     @Value("${toss.payments.secret-key:}")
     private String secretKey;
@@ -43,11 +45,13 @@ public class TossPaymentController {
             @RequestParam String paymentKey,
             @RequestParam String orderId,
             @RequestParam int amount) {
+        // 다시 돌아갈 채팅창 URL
+        String chatURL = redirectToChat(orderId);
+
         if (secretKey == null || secretKey.isBlank()) {
             orderService.recordPaymentFailure(orderId, "서버 설정 오류로 결제 결과를 처리하지 못했습니다.");
             // 토스 리다이렉트 착지 응답은 필요하지만, 결과 화면을 보여주지 않고 채팅방 시스템 메시지로 전달하기 때문에 302로 이동.
-            // (채팅 URL이 정해지면 여기 Location("/")만 채팅방 URL로 바꾸면 됨)
-            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
+            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
         }
 
         // Toss confirm 호출 전 사전 금액 검증 (돈 묶이기 전에 차단) + 이미 PAID면 멱등 허용
@@ -55,7 +59,7 @@ public class TossPaymentController {
             orderService.verifyPaymentAmount(orderId, amount);
         } catch (BusinessException e) {
             orderService.recordPaymentFailure(orderId, e.getMessage());
-            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
+            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
         }
 
         // Basic 인증: {secretKey}: 를 Base64 인코딩
@@ -88,21 +92,20 @@ public class TossPaymentController {
             orderService.confirmPayment(orderId, confirmedAmount);
 
             // 토스 리다이렉트 착지 응답은 필요하지만, 결과 화면을 보여주지 않고 채팅방 시스템 메시지로 전달하기 때문에 302로 이동.
-            // (채팅 URL이 정해지면 여기 Location("/")만 채팅방 URL로 바꾸면 됨)
             return ResponseEntity.status(302)
-                    .header(HttpHeaders.LOCATION, "/")
+                    .header(HttpHeaders.LOCATION, chatURL)
                     .build();
         } catch (RestClientResponseException e) {
             orderService.recordPaymentFailure(orderId,
                     parseTossErrorMessage(e.getResponseBodyAsString()));
-            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
+            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
         } catch (BusinessException e) {
             // confirm은 성공했는데 DB 반영이 실패한 케이스도 채팅 메시지로 남김
             orderService.recordPaymentFailure(orderId, e.getMessage());
-            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
+            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
         } catch (Exception e) {
             orderService.recordPaymentFailure(orderId, e.getMessage());
-            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
+            return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
         }
     }
 
@@ -112,6 +115,9 @@ public class TossPaymentController {
             @RequestParam(required = false) String code,
             @RequestParam(required = false) String message,
             @RequestParam(required = false) String orderId) {
+        // 다시 돌아갈 채팅창 URL
+        String chatURL = redirectToChat(orderId);
+
         String reason = (message == null || message.isBlank()) ? null : message;
         if (code != null && !code.isBlank()) {
             reason = (reason == null) ? code : reason + " (" + code + ")";
@@ -120,8 +126,7 @@ public class TossPaymentController {
         orderService.recordPaymentFailure(orderId, reason);
 
         // 토스 리다이렉트 착지 응답은 필요하지만, 결과 화면을 보여주지 않고 채팅방 시스템 메시지로 전달하기 때문에 302로 이동.
-        // (채팅 URL이 정해지면 여기 Location("/")만 채팅방 URL로 바꾸면 됨)
-        return ResponseEntity.status(302).header(HttpHeaders.LOCATION, "/").build();
+        return ResponseEntity.status(302).header(HttpHeaders.LOCATION, chatURL).build();
     }
 
     private String parseTossErrorMessage(String responseBody) {
@@ -138,5 +143,14 @@ public class TossPaymentController {
             // 파싱 실패 시 원문 반환
         }
         return responseBody;
+    }
+
+    private String redirectToChat(String tossOrderId) {
+        if (tossOrderId == null || tossOrderId.isBlank()) {
+            return "/";
+        }
+        return orderRepository.findByOrderNumber(tossOrderId)
+                .map(o -> "/chat/" + o.getChatRoom().getId())
+                .orElse("/");
     }
 }

--- a/src/main/java/com/knoc/order/controller/TossPaymentController.java
+++ b/src/main/java/com/knoc/order/controller/TossPaymentController.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestClient;

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -51,8 +51,12 @@ public class OrderService {
 
     @Transactional
     public OrderResponse createOrderRequest(OrderRequest dto, Long seniorId, String idempotencyKey) {
-        // 0. 멱등키 검증 (비어있거나 너무 짧은 경우에 대한 에러 처리)
-        if (!StringUtils.hasText(idempotencyKey) || idempotencyKey.trim().length() < 10) {
+        // 0. 멱등키 검증 (비어있거나 너무 짧거나 너무 긴 경우에 대한 에러 처리)
+        // Toss 제약: orderId 6~64자
+        // idempotencyKey가 60자 초과면 orderNumber가 64자 초과이므로 에러.
+        if (!StringUtils.hasText(idempotencyKey)
+                || idempotencyKey.trim().length() < 10
+                || idempotencyKey.trim().length() > 60) { // "ORD-" prefix 4자 여유
             throw new BusinessException(ErrorCode.INVALID_IDEMPOTENCY_KEY);
         }
 

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 //
 @Slf4j
 @Service
-@Transactional
+@Transactional(readOnly = true) // 클래스 기본값: 읽기 전용 (쓰기 메서드에만 @Transactional 명시)
 @RequiredArgsConstructor
 public class OrderService {
     private final OrderRepository orderRepository;
@@ -185,6 +185,7 @@ public class OrderService {
     // NOTE: verifyPaymentAmount에서 이미 동일한 입력/조회 체크가 수행될 수 있지만,
     // confirmPayment도 단독 호출 가능한 public 엔트리포인트이므로 방어적으로 재검증/재조회를 수행함
     // (defense-in-depth, 쿼리 비용은 UNIQUE 인덱스 조회라 무시 가능)
+    @Transactional
     public Optional<OrderResponse> confirmPayment(String tossOrderId, long confirmedAmount) {
         if (tossOrderId == null || tossOrderId.isBlank()) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
@@ -252,6 +253,7 @@ public class OrderService {
     // 주문이 존재하면 채팅방에 시스템 메시지를 저장함
     // 주문이 없으면(예: TEST-...) 아무 것도 하지 않음
     // 주문 상태는 기본적으로 변경하지 않음(PENDING 유지)
+    @Transactional
     public void recordPaymentFailure(String tossOrderId, String reason) {
         if (tossOrderId == null || tossOrderId.isBlank()) {
             return; // 토스 fail 콜백에서 orderId가 없을 수 있어 조용히 무시

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -278,8 +278,9 @@ public class OrderService {
             return;
         }
 
-        // 결제 실패에 대한 로그
-        log.warn("결제 실패 처리: orderId={}, reason={}", order.getId(), reason);
+        // 채팅방에 실패 메시지가 실제로 발행되는 시점의 정상 플로우 로그
+        // (에러 발생 자체는 호출부 컨트롤러에서 WARN으로 별도 기록됨)
+        log.info("PAYMENT_FAILED 이벤트 발행: orderId={}, reason={}", order.getId(), reason);
 
         // 결제 실패 시스템 이벤트 발행
         eventPublisher.publishEvent(new ChatSystemEvent(

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -113,19 +113,15 @@ public class OrderService {
     public OrderResponse preparePayment(Long orderId, Long juniorId) {
         // 입력 검증
         if (juniorId == null) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        // 주문 조회
-        if (orderId == null) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-        }
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
         // 주니어 검증
         if (order.getJunior() == null || order.getJunior().getId() == null) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
         if (!order.getJunior().getId().equals(juniorId)) {
             throw new BusinessException(ErrorCode.NOT_JUNIOR_FOR_ORDER);
@@ -153,12 +149,12 @@ public class OrderService {
     public void verifyPaymentAmount(String tossOrderId, int amount) {
         // 음수 방어 (쿼리 변조로 음수 전달 가능)
         if (amount < 0) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            throw new BusinessException(ErrorCode.ORDER_INVALID_AMOUNT);
         }
 
         // OrderId가 없거나 빈 값이면 에러
-        if (tossOrderId == null || tossOrderId.isBlank()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        if (!StringUtils.hasText(tossOrderId)) {
+            throw new BusinessException(ErrorCode.ORDER_INVALID_ORDER_NUMBER);
         }
 
         Optional<Order> found = orderRepository.findByOrderNumber(tossOrderId);
@@ -187,8 +183,8 @@ public class OrderService {
     // (defense-in-depth, 쿼리 비용은 UNIQUE 인덱스 조회라 무시 가능)
     @Transactional
     public Optional<OrderResponse> confirmPayment(String tossOrderId, long confirmedAmount) {
-        if (tossOrderId == null || tossOrderId.isBlank()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        if (!StringUtils.hasText(tossOrderId)) {
+            throw new BusinessException(ErrorCode.ORDER_INVALID_ORDER_NUMBER);
         }
         Optional<Order> found = orderRepository.findByOrderNumber(tossOrderId);
         if (found.isEmpty()) {
@@ -255,7 +251,7 @@ public class OrderService {
     // 주문 상태는 기본적으로 변경하지 않음(PENDING 유지)
     @Transactional
     public void recordPaymentFailure(String tossOrderId, String reason) {
-        if (tossOrderId == null || tossOrderId.isBlank()) {
+        if (!StringUtils.hasText(tossOrderId)) {
             return; // 토스 fail 콜백에서 orderId가 없을 수 있어 조용히 무시
         }
         Optional<Order> found = orderRepository.findByOrderNumber(tossOrderId);

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -110,11 +110,8 @@ public class OrderService {
 
     // 결제창 호출 전 단계(사전 검증/조회)
     // 실제 결제 승인 후 처리는 confirmPayment(String, long) 메서드에서 수행
-    public OrderResponse preparePayment(Long orderId, String idempotencyKey, Long juniorId) {
+    public OrderResponse preparePayment(Long orderId, Long juniorId) {
         // 입력 검증
-        if (!StringUtils.hasText(idempotencyKey) || idempotencyKey.trim().length() < 10) {
-            throw new BusinessException(ErrorCode.INVALID_IDEMPOTENCY_KEY);
-        }
         if (juniorId == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,3 +38,8 @@ email.blocked-domains=naver.com,daum.net,kakao.com,hanmail.net
 # - 시크릿 키: 서버에서 결제 승인(confirm)에만 사용
 toss.payments.client-key=${TOSS_CLIENT_KEY:}
 toss.payments.secret-key=${TOSS_SECRET_KEY:}
+# - base-url: 토스페이먼츠 API 서버 주소 (RestClient baseUrl)
+# - connect-timeout / read-timeout: 토스 API 호출 타임아웃 (스레드 블록 방지)
+toss.payments.base-url=https://api.tosspayments.com
+toss.payments.connect-timeout=3s
+toss.payments.read-timeout=10s

--- a/src/test/java/com/knoc/order/service/OrderServiceTest.java
+++ b/src/test/java/com/knoc/order/service/OrderServiceTest.java
@@ -526,12 +526,12 @@ class OrderServiceTest {
     // ============================================================
 
     @Test
-    @DisplayName("사전 금액 검증: 음수 amount면 INVALID_INPUT_VALUE 예외(주문 조회 이전에 차단)")
+    @DisplayName("사전 금액 검증: 음수 amount면 ORDER_INVALID_AMOUNT 예외(주문 조회 이전에 차단)")
     void verifyPaymentAmount_Throws_OnNegativeAmount() {
         // when & then
         assertThatThrownBy(() -> orderService.verifyPaymentAmount("ORD-NEG", -1))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+                .hasMessage(ErrorCode.ORDER_INVALID_AMOUNT.getMessage());
 
         // 음수면 조회까지 가지 않아야 함
         verify(orderRepository, never()).findByOrderNumber(any());

--- a/src/test/java/com/knoc/order/service/OrderServiceTest.java
+++ b/src/test/java/com/knoc/order/service/OrderServiceTest.java
@@ -165,7 +165,6 @@ class OrderServiceTest {
         // given
         Long orderId = 100L;
         Long juniorId = 2L;
-        String idempotencyKey = "idempotencyKey-123";
 
         ChatRoom chatRoom = mock(ChatRoom.class);
         given(chatRoom.getId()).willReturn(10L);
@@ -184,7 +183,7 @@ class OrderServiceTest {
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
         // when
-        OrderResponse response = orderService.preparePayment(orderId, idempotencyKey, juniorId);
+        OrderResponse response = orderService.preparePayment(orderId, juniorId);
 
         // then
         assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.PENDING);
@@ -201,7 +200,6 @@ class OrderServiceTest {
         // given
         Long orderId = 101L;
         Long juniorId = 2L;
-        String idempotencyKey = "idempotencyKey-456";
 
         ChatRoom chatRoom = mock(ChatRoom.class);
         Member junior = mock(Member.class);
@@ -219,7 +217,7 @@ class OrderServiceTest {
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
         // when
-        OrderResponse response = orderService.preparePayment(orderId, idempotencyKey, juniorId);
+        OrderResponse response = orderService.preparePayment(orderId, juniorId);
 
         // then
         assertThat(response.getOrderStatus()).isEqualTo(OrderStatus.PAID);
@@ -273,7 +271,6 @@ class OrderServiceTest {
         Long orderId = 102L;
         Long actualJuniorId = 2L;
         Long attackerJuniorId = 999L;
-        String idempotencyKey = "idempotencyKey-789";
 
         Member junior = mock(Member.class);
         given(junior.getId()).willReturn(actualJuniorId);
@@ -289,7 +286,7 @@ class OrderServiceTest {
         given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
 
         // when & then
-        assertThatThrownBy(() -> orderService.preparePayment(orderId, idempotencyKey, attackerJuniorId))
+        assertThatThrownBy(() -> orderService.preparePayment(orderId, attackerJuniorId))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(ErrorCode.NOT_JUNIOR_FOR_ORDER.getMessage());
 


### PR DESCRIPTION
## 🔎 What

- Toss success/fail 동적 리다이렉트 URL — 홈이 아닌 원래 채팅방으로 복귀
- RestClient 빈 추출 + 타임아웃 설정 — 운영 장애 방지(블록 방어), Basic 인증 헤더 자동 주입
- 결제 실패 메시지 정제 — 토스 에러 원문 / 내부 예외 메시지가 채팅방에 노출되는 문제 차단
- preparePayment의 Idempotency-Key 요구 제거 — 조회/검증 전용 메서드에 멱등키가 무의미함
- @Transactional(readOnly = true) 정리 — 읽기 메서드 최적화 및 중복 선언 제거
- Toss 엔드포인트 파라미터 방어 코드 — paymentKey/orderId/amount 최소 검증
- TossPaymentController를 @RestController로 변경 — 컨트롤러 내 모든 메서드가 Body 없이 302만 반환하므로 클래스 자체를 @RestController로 바꿔도 무방
- ErrorCode 세분화 — ORDER_INVALID_AMOUNT, ORDER_INVALID_ORDER_NUMBER 신설 / 내부 무결성은 INTERNAL_SERVER_ERROR로 이관
- createOrderRequest의 멱등키 검증 추가 — 멱등키가 60 초과일 경우 주문번호가 64 초과가 되므로 60 초과일 때 에러 처리하도록 검증 추가

## 🔗 Issue

- Closes: #75 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?

