### PR TITLE
fix: 시니어 지원/상세/헤더 권한 및 UI 정비

### DIFF
--- a/src/main/java/com/knoc/global/config/SecurityConfig.java
+++ b/src/main/java/com/knoc/global/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 // url 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         // [공통/비로그인] AUTH-01(로그인), POST-02(후기 목록 조회-비로그인 가능 명시)
-                        .requestMatchers("/", "/auth/**", "/error/**", "/reviews/posts", "/orders/payment/toss/**", "/css/**", "/js/**", "/images/**", "/ws/**").permitAll()
+                        .requestMatchers("/", "/auth/**", "/error/**", "/reviews/posts", "/orders/payment/toss/**", "/senior/apply", "/css/**", "/js/**", "/images/**", "/ws/**").permitAll()
                         // [시니어 전용] PROF-01(프로필 관리), REV-02(리포트 제출), MY-02(시니어 마이페이지), ORD-01(결제 요청)
                         .requestMatchers("/senior/profile/**", "/reports/**", "/my/senior/**", "/orders/request").hasRole("SENIOR")
                         // [주니어 전용] CHAT-01(방생성), ORD-01/02(결제), REV-01(요청), SET-01(구매확정), POST-01(후기작성), MY-01(주니어 마이페이지)

--- a/src/main/java/com/knoc/senior/controller/SeniorApplyController.java
+++ b/src/main/java/com/knoc/senior/controller/SeniorApplyController.java
@@ -33,8 +33,8 @@ public class SeniorApplyController {
 
     @Operation(summary = "시니어 지원 안내 페이지", description = "시니어 지원을 위한 안내 페이지를 보여줍니다.")
     @GetMapping("/apply")
-    @PreAuthorize("hasRole('USER')")
     public String apply() {
+        // 비로그인/주니어/시니어 모두 접근 가능한 공개 안내 페이지
         return "senior/apply";
     }
 

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
 <header th:fragment="headerFragment">
-    <nav class="navbar navbar-expand-lg navbar-dark header-nav">
+    <nav class="navbar navbar-expand-lg navbar-dark header-nav fixed-top">
         <div class="container">
             <a class="navbar-brand fw-bold fs-4 d-inline-flex align-items-center gap-2" th:href="@{/}">
                 <img src="/images/Knoc_logo.png" alt="Knoc 로고" class="knoc-logo"/>
@@ -39,15 +39,13 @@
                 <div class="d-flex align-items-center gap-3" sec:authorize="isAuthenticated()">
                     <a th:href="@{/my/dashboard}" class="text-decoration-none text-white">내 멘토링</a>
 
-                    <span class="badge rounded-pill px-3 py-2"
-                          style="background-color: #20c997; font-size: 0.8rem"
-                          sec:authorize="hasAuthority('SENIOR')">시니어</span>
-                    <span class="badge rounded-pill px-3 py-2 bg-secondary"
-                          style="font-size: 0.8rem"
-                          sec:authorize="hasAuthority('USER')">주니어</span>
+                    <span class="hero-pill text-mint" style="font-size: 0.9rem;"
+                          sec:authorize="hasRole('SENIOR')">시니어</span>
+                    <span class="hero-pill hero-pill--violet" style="font-size: 0.9rem;"
+                          sec:authorize="hasRole('USER')">주니어</span>
 
                     <form th:action="@{/auth/logout}" method="post" class="m-0">
-                        <button type="submit" class="btn btn-outline-light rounded-pill px-4">로그아웃</button>
+                        <button type="submit" class="btn btn-link text-decoration-none text-white p-0">로그아웃</button>
                     </form>
                 </div>
             </div>

--- a/src/main/resources/templates/layout/default_layout.html
+++ b/src/main/resources/templates/layout/default_layout.html
@@ -6,6 +6,7 @@
     <title layout:title-pattern="$CONTENT_TITLE">Knoc.</title>
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 
     <style>
         body {

--- a/src/main/resources/templates/senior/apply.html
+++ b/src/main/resources/templates/senior/apply.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="ko"
       xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout/default_layout}">
 
@@ -80,13 +81,34 @@
         <div class="cta-card p-5 mx-auto" style="max-width: 640px;">
             <p class="text-secondary small mb-3">현직자 인증하고 시니어 지원하기</p>
             <div class="d-grid mb-3">
-                <a th:href="@{/senior/apply/auth}"
+                <!--
+                시니어 지원 버튼: 권한에 따라 둘 중 하나만 렌더링됨 (동시에 보이지 않음)
+                비시니어(비로그인/주니어) : <a> 활성 링크
+                시니어                 : <button disabled> 버튼 비활성 상태
+                (a 태그는 native disabled 미지원 → 비활성 상태는 button 으로 분리)
+                -->
+                    <a sec:authorize="!hasRole('SENIOR')"
+                   th:href="@{/senior/apply/auth}"
                    class="btn btn-gradient btn-lg rounded-3 py-3 d-flex align-items-center justify-content-center gap-2">
                     시니어 지원하기 <span>›</span>
                 </a>
+                <button sec:authorize="hasRole('SENIOR')"
+                        type="button" disabled
+                        class="btn btn-gradient btn-lg rounded-3 py-3 d-flex align-items-center justify-content-center gap-2">
+                    시니어 지원하기 <span>›</span>
+                </button>
             </div>
-            <p class="text-secondary mb-0">
+            <!--
+            비로그인: 지원하기 전 먼저 로그인을 해주세요.
+            시니어: 이미 시니어 인증이 완료되었습니다.
+            주니어: 아래 <p> 문구가 안 뜸
+            -->
+            <p class="text-secondary mb-0" sec:authorize="!isAuthenticated()">
                 지원하기 전 먼저 <a th:href="@{/auth/login}" class="text-mint text-decoration-none fw-semibold">로그인</a>을 해주세요.
+            </p>
+            <p class="text-secondary mb-0" sec:authorize="hasRole('SENIOR')">
+                이미 시니어로 활동 중이에요 🙌
+                <a th:href="@{/my/dashboard}" class="text-mint text-decoration-none fw-semibold">내 멘토링 보러 가기</a>
             </p>
         </div>
     </section>

--- a/src/main/resources/templates/senior/detail.html
+++ b/src/main/resources/templates/senior/detail.html
@@ -7,7 +7,7 @@
     <style>
         /* 메인 페이지(index)와 완벽히 통일된 컬러 팔레트 */
         .card-dark { background-color: #161b27; border: 1px solid #2a2f40; }
-        .card-inner-dark { background-color: #1e1e1e; border: 1px solid #333; }
+        .card-inner-dark { background-color: #262c38; border: 1px solid rgba(255, 255, 255, 0.08); }
         .text-mint { color: #00CFE8 !important; }
         .bg-mint { background-color: #00CFE8 !important; color: #161b27 !important; }
         .border-mint { border-color: #00CFE8 !important; }
@@ -20,14 +20,14 @@
 <div layout:fragment="content" class="container py-5 mt-5">
 
     <div class="card card-dark p-4 p-md-5 rounded-4 mb-4 position-relative overflow-hidden">
-        <div class="d-flex flex-column flex-md-row gap-4 align-items-md-center position-relative z-1">
-            <div class="position-relative" style="width: 120px; height: 120px; flex-shrink: 0;">
+        <div class="d-flex flex-column flex-md-row gap-4 align-items-md-start position-relative z-1">
+            <div class="position-relative" style="width: 150px; height: 150px; flex-shrink: 0;">
                 <img th:if="${senior.profileImageUrl != null and !senior.profileImageUrl.isEmpty()}"
                      th:src="${senior.profileImageUrl}"
                      alt="시니어 프로필" class="w-100 h-100 rounded-circle object-fit-cover shadow" style="border: 2px solid #2a2f40;">
                 <div th:unless="${senior.profileImageUrl != null and !senior.profileImageUrl.isEmpty()}"
                      class="w-100 h-100 rounded-circle shadow d-flex align-items-center justify-content-center"
-                     style="border: 2px solid #2a2f40; background-color: #2a2f40; font-size: 3.5rem; line-height: 1;">
+                     style="border: 2px solid #2a2f40; background-color: #2a2f40; font-size: 4.5rem; line-height: 1;">
                     👤
                 </div>
             </div>
@@ -38,9 +38,9 @@
 
                     <div class="d-flex align-items-center w-50">
                         <h2 class="fw-bold text-white mb-0 me-3" th:text="${senior.nickname}">정백엔드</h2>
-                        <span class="badge border border-mint text-mint bg-transparent px-2 py-1 rounded-pill">
-            <i class="bi bi-shield-check me-1"></i> 현직자 인증완료
-        </span>
+                        <span class="badge border border-mint text-mint bg-transparent px-2 py-2 rounded-pill fw-semibold d-inline-flex align-items-center">
+                            <i class="bi bi-shield-check me-2"></i> 현직자 인증완료
+                        </span>
                     </div>
 
                     <div class="d-flex align-items-center w-50 ps-4">
@@ -71,7 +71,8 @@
                 </p>
 
                 <div class="d-flex flex-wrap gap-2 mb-4">
-                    <span class="badge bg-secondary px-3 py-2 rounded-pill fw-normal"
+                    <span class="badge px-3 py-2 rounded-pill fw-medium text-white"
+                          style="background-color: #1e2a3c; border: 1px solid rgba(255,255,255,0.08);"
                           th:each="skill : ${senior.skills}" th:text="${skill}">Spring Boot</span>
                 </div>
 
@@ -143,7 +144,8 @@
                 </p>
 
                 <form th:action="@{|/chats/start/${senior.id}|}" method="post" class="w-100">
-                    <button type="submit" class="btn btn-outline-light rounded-pill w-100 py-3 fw-bold fs-6 shadow-sm mb-3">
+                    <button type="submit" class="btn btn-outline-light rounded-pill w-100 py-3 fw-bold fs-6 shadow-sm mb-3 d-inline-flex align-items-center justify-content-center gap-3">
+                        <i class="bi bi-chat"></i>
                         1:1 채팅으로 조율하기
                     </button>
                 </form>


### PR DESCRIPTION
## 🔎 What

- '시니어 지원하기' 페이지 비로그인도 접근 가능하게 권한 수정
- '시니어 지원하기' CTA를 역할별 분리 렌더링 (비로그인/주니어/시니어)

### 비로그인
<img width="838" height="342" alt="image" src="https://github.com/user-attachments/assets/b7560b47-ca7e-42ea-bf7b-5190929f6024" />

### 주니어 
<img width="856" height="318" alt="image" src="https://github.com/user-attachments/assets/b8cd5652-aa00-4bce-9392-94fb2c26be03" />

### 시니어
<img width="823" height="316" alt="image" src="https://github.com/user-attachments/assets/905d5580-5a99-40f9-ab3f-9109be75382e" />

- 시니어/주니어 뱃지 역할에 맞게 표시하고 UI 개선 (+로그아웃 버튼을 로그인 버튼 스타일로 통일)
<img width="311" height="54" alt="image" src="https://github.com/user-attachments/assets/05e48a52-4134-4b00-9836-53e56edb3acb" />
<img width="312" height="57" alt="image" src="https://github.com/user-attachments/assets/ea2da232-aafd-418f-b19e-540b48fdf6a3" />

- 헤더를 화면에 고정
- 시니어 상세 페이지 UI 개선
  - 프로필 이미지 크기 확대 및 상단 정렬
  - "현직자 인증완료" 크기 조정
  - 스킬 태그 스타일 개선 (다크 네이비 배경 + 흰색 텍스트)
  - 평점/가격/AI 인사이트/자기소개 카드 배경 톤 통일
  - "1:1 채팅으로 조율하기" 버튼에 말풍선 아이콘 추가

### Before
<img width="1653" height="807" alt="image" src="https://github.com/user-attachments/assets/3f70e777-7237-42b1-bed2-cd9b6e7e7845" />

### After
<img width="1641" height="839" alt="image" src="https://github.com/user-attachments/assets/e796f46a-c276-4938-b7c1-f87079862c25" />

## 🔗 Issue

- Closes: #85 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?

