### PR TITLE
[feat] 채팅 도메인 통합 테스트

### DIFF
--- a/src/main/java/com/knoc/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/knoc/auth/jwt/JwtAuthenticationFilter.java
@@ -51,6 +51,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
 
     }
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        // /ws 로 시작하는 웹소켓 연결 요청은 HTTP 단계에서 토큰 검사를 하지 않도록 예외 처리
+        return path.startsWith("/ws");
+    }
 
     // 쿠키 배열에서 원하는 쿠키를 가져옴
     private String getCookieValue(HttpServletRequest request, String cookieName) {

--- a/src/main/java/com/knoc/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/com/knoc/chat/dto/ChatMessageRequest.java
@@ -1,8 +1,12 @@
 package com.knoc.chat.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ChatMessageRequest {
     // JWT 인증완료 -> 내용만 보내고 Principal로 검증
 

--- a/src/main/java/com/knoc/global/config/WebSocketConfig.java
+++ b/src/main/java/com/knoc/global/config/WebSocketConfig.java
@@ -3,7 +3,14 @@ package com.knoc.global.config; // 1. 팀원의 글로벌 패키지 위치로 �
 import com.knoc.auth.jwt.JwtHandshakeInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -37,5 +44,26 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setAllowedOriginPatterns("*")
                 .addInterceptors(jwtHandshakeInterceptor)
                 .withSockJS();
+    }
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+                // ✅ CONNECT에만 한정하지 않고, 세션에 인증 객체가 있다면 항상 달아줍니다!
+                if (accessor != null && accessor.getSessionAttributes() != null) {
+                    Object principal = accessor.getSessionAttributes().get("principal");
+
+                    if (principal instanceof java.security.Principal) {
+                        // STOMP 세션의 공식 유저로 등록!
+                        accessor.setUser((java.security.Principal) principal);
+                    }
+                }
+
+                return message;
+            }
+        });
     }
 }

--- a/src/test/java/com/knoc/chat/ChatIntegrationTest.java
+++ b/src/test/java/com/knoc/chat/ChatIntegrationTest.java
@@ -1,0 +1,220 @@
+package com.knoc.chat;
+
+import com.knoc.auth.jwt.JwtTokenProvider;
+import com.knoc.chat.dto.ChatMessageRequest;
+import com.knoc.chat.entity.ChatRoom;
+import com.knoc.chat.entity.ChatSystemEvent;
+import com.knoc.chat.entity.MessageType;
+import com.knoc.chat.repository.ChatMessageRepository;
+import com.knoc.chat.repository.ChatRoomRepository;
+import com.knoc.member.Member;
+import com.knoc.member.MemberRepository;
+import com.knoc.member.MemberRole;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class ChatIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @AfterEach
+    void tearDown() {
+        chatMessageRepository.deleteAllInBatch();
+        chatRoomRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    private WebSocketStompClient stompClient;
+    private StompHeaders stompHeaders;
+    private WebSocketHttpHeaders httpHeaders;
+
+    private Long activeRoomId;
+    private Long closedRoomId;
+
+    @BeforeEach
+    void setup() {
+        Member senior = memberRepository.save(Member.builder()
+                .email("senior@test.com")
+                .password("password")
+                .nickname("시니어멘토")
+                .role(MemberRole.SENIOR)
+                .build());
+
+        Member junior = memberRepository.save(Member.builder()
+                .email("junior@test.com")
+                .password("password")
+                .nickname("주니어")
+                .role(MemberRole.USER)
+                .build());
+
+        ChatRoom activeRoom = chatRoomRepository.save(ChatRoom.builder()
+                .senior(senior)
+                .junior(junior)
+                .build());
+        activeRoomId = activeRoom.getId();
+
+        ChatRoom closedRoom = chatRoomRepository.save(ChatRoom.builder()
+                .senior(senior)
+                .junior(junior)
+                .build());
+        closedRoom.close();
+        chatRoomRepository.save(closedRoom);
+        closedRoomId = closedRoom.getId();
+
+        // SockJS & STOMP 클라이언트 생성
+        List<Transport> transports = List.of(new WebSocketTransport(new StandardWebSocketClient()));
+        SockJsClient sockJsClient = new SockJsClient(transports);
+
+        stompClient = new WebSocketStompClient(sockJsClient);
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+        String validToken = jwtTokenProvider.createAccessToken(senior.getEmail(), "ROLE_SENIOR");
+
+        // 보안(Security) 통과를 위한 헤더 세팅
+        stompHeaders = new StompHeaders();
+        stompHeaders.add("Authorization", "Bearer " + validToken);   // STOMP
+
+        httpHeaders = new WebSocketHttpHeaders();
+        httpHeaders.add("Cookie", "accessToken=" + validToken);   // HTTP handshake
+    }
+
+    private class TestFrameHandler implements StompFrameHandler {
+        private final BlockingQueue<Map<String, Object>> queue;
+        public TestFrameHandler(BlockingQueue<Map<String, Object>> queue) { this.queue = queue; }
+
+        @Override
+        public Type getPayloadType(StompHeaders headers) { return Map.class; }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void handleFrame(StompHeaders headers, Object payload) {
+            queue.offer((Map<String, Object>) payload);
+        }
+    }
+
+    private String getWebSocketUrl() {
+        return String.format("ws://localhost:%d/ws", port);
+    }
+
+    @Test
+    @DisplayName("[통합] 1:1 큐 구독 후 메시지를 전송하면 정상적으로 수신한다.")
+    void stomp_SendMessage_And_Receive_Success() throws Exception {
+        BlockingQueue<Map<String, Object>> blockingQueue = new ArrayBlockingQueue<>(1);
+
+        StompSession session = stompClient.connectAsync(
+                getWebSocketUrl(),
+                httpHeaders,
+                stompHeaders,
+                new StompSessionHandlerAdapter() {}
+        ).get(3, TimeUnit.SECONDS);
+
+        session.subscribe("/user/queue/chat", new TestFrameHandler(blockingQueue));
+
+        // 구독이 서버에 확실히 등록되도록 1초 대기
+        Thread.sleep(1000);
+
+        ChatMessageRequest request = new ChatMessageRequest("통합 테스트 메시지입니다.");
+        session.send("/app/" + activeRoomId + "/send", request);
+
+        Map<String, Object> response = blockingQueue.poll(3, TimeUnit.SECONDS);
+        assertThat(response).isNotNull();
+        assertThat(response.get("content").toString()).isEqualTo("통합 테스트 메시지입니다.");
+    }
+
+    @Test
+    @DisplayName("[통합] 서버에서 시스템 이벤트를 발행하면 구독 중인 클라이언트로 실시간 전송된다.")
+    void stomp_Receive_System_Event_Success() throws Exception {
+        BlockingQueue<Map<String, Object>> blockingQueue = new ArrayBlockingQueue<>(1);
+
+        StompSession session = stompClient.connectAsync(
+                getWebSocketUrl(),
+                httpHeaders,
+                stompHeaders,
+                new StompSessionHandlerAdapter() {}
+        ).get(3, TimeUnit.SECONDS);
+
+        session.subscribe("/user/queue/chat", new TestFrameHandler(blockingQueue));
+
+        Thread.sleep(1000);
+
+        eventPublisher.publishEvent(new ChatSystemEvent(
+                activeRoomId,
+                MessageType.PAYMENT_COMPLETED,
+                "결제가 완료되었습니다.",
+                999L
+        ));
+
+        Map<String, Object> response = blockingQueue.poll(3, TimeUnit.SECONDS);
+        assertThat(response).isNotNull();
+        assertThat(response.get("messageType").toString()).isEqualTo("PAYMENT_COMPLETED");
+        assertThat(response.get("content").toString()).contains("결제가 완료");
+    }
+
+    @Test
+    @DisplayName("[통합] 마감된 채팅방에 메시지를 전송하면 서버가 거부한다 (수신되지 않음).")
+    void stomp_SendMessage_To_ClosedRoom_Fail() throws Exception {
+        BlockingQueue<Map<String, Object>> blockingQueue = new ArrayBlockingQueue<>(1);
+
+        StompSession session = stompClient.connectAsync(
+                getWebSocketUrl(),
+                httpHeaders,
+                stompHeaders,
+                new StompSessionHandlerAdapter() {}
+        ).get(3, TimeUnit.SECONDS);
+
+        session.subscribe("/user/queue/chat", new TestFrameHandler(blockingQueue));
+
+        Thread.sleep(500);
+
+        ChatMessageRequest request = new ChatMessageRequest("마감된 방에 몰래 보내기");
+        session.send("/app/" + closedRoomId + "/send", request);
+
+        Map<String, Object> response = blockingQueue.poll(2, TimeUnit.SECONDS);
+        assertThat(response).isNull();
+    }
+}

--- a/src/test/java/com/knoc/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/knoc/chat/service/ChatMessageServiceTest.java
@@ -1,0 +1,88 @@
+package com.knoc.chat.service;
+
+import com.knoc.chat.dto.ChatMessageResponse;
+import com.knoc.chat.entity.ChatMessage;
+import com.knoc.chat.entity.ChatRoom;
+import com.knoc.chat.repository.ChatMessageRepository;
+import com.knoc.chat.repository.ChatRoomRepository;
+import com.knoc.member.Member;
+import com.knoc.member.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ChatMessageServiceTest {
+
+    @InjectMocks
+    private ChatMessageService chatMessageService;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Test
+    @DisplayName("메시지를 전송하면 DB에 저장되고 1:1 큐 방식으로 양쪽 유저에게 발송된다.")
+    void sendMessage_Success() {
+        // given
+        Long roomId = 1L;
+        Long senderId = 10L;
+        String content = "안녕하세요";
+
+        // 1. 참여자(Junior, Senior) Mock 생성
+        Member junior = mock(Member.class);
+        Member senior = mock(Member.class);
+
+        // 💡 실제 로직에서 sender.getNickname()을 사용하므로 닉네임 스터빙 추가
+        given(junior.getId()).willReturn(senderId);
+        given(junior.getEmail()).willReturn("junior@test.com");
+        given(junior.getNickname()).willReturn("주니어닉네임"); // 추가됨
+
+        given(senior.getId()).willReturn(20L);
+        given(senior.getEmail()).willReturn("senior@test.com");
+
+        // 2. ChatRoom 생성 (ID 주입)
+        ChatRoom chatRoom = ChatRoom.builder()
+                .junior(junior)
+                .senior(senior)
+                .build();
+        ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+        // 3. Mock Repository 설정
+        given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(chatRoom));
+        given(memberRepository.findById(senderId)).willReturn(Optional.of(junior));
+
+        // 4. 저장된 메시지 Mock (로직에서 사용하는 필드만 스터빙)
+        ChatMessage mockSavedMessage = mock(ChatMessage.class);
+        given(chatMessageRepository.save(any(ChatMessage.class))).willReturn(mockSavedMessage);
+        given(mockSavedMessage.getContent()).willReturn(content);
+
+        // when
+        chatMessageService.sendMessage(roomId, senderId, content);
+
+        // then
+        verify(chatMessageRepository).save(any(ChatMessage.class));
+        verify(messagingTemplate).convertAndSendToUser(eq("junior@test.com"), eq("/queue/chat"), any(ChatMessageResponse.class));
+        verify(messagingTemplate).convertAndSendToUser(eq("senior@test.com"), eq("/queue/chat"), any(ChatMessageResponse.class));
+    }
+}

--- a/src/test/java/com/knoc/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/knoc/chat/service/ChatRoomServiceTest.java
@@ -1,0 +1,94 @@
+package com.knoc.chat.service;
+
+import com.knoc.chat.entity.ChatRoom;
+import com.knoc.chat.entity.ChatRoomStatus;
+import com.knoc.chat.entity.ChatSystemEvent;
+import com.knoc.chat.repository.ChatRoomRepository;
+import com.knoc.global.exception.BusinessException;
+import com.knoc.member.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class ChatRoomServiceTest {
+
+    @InjectMocks
+    private ChatRoomService chatRoomService;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Test
+    @DisplayName("채팅방 마감이 요청되면 상태가 CLOSED 변경되고 이벤트가 발행된다.")
+    void closeChatRoom_Success() {
+        // given
+        Long roomId = 1L;
+        Long seniorId = 10L;
+
+        Member senior = mock(Member.class);
+        given(senior.getId()).willReturn(seniorId);
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .junior(mock(Member.class))
+                .senior(senior)
+                .build();
+
+        // 2. id는 빌더에 없으므로 ReflectionTestUtils로 강제 주입
+        ReflectionTestUtils.setField(chatRoom, "id", roomId);
+        // 기본값은 ACTIVE이므로 별도 세팅 불필요 (엔티티 생성자에서 세팅됨)
+
+        given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(chatRoom));
+
+        // when
+        chatRoomService.closeChatRoom(roomId, seniorId);
+
+        // then
+        assertThat(chatRoom.getStatus()).isEqualTo(ChatRoomStatus.CLOSED); // close() 메서드 작동 확인
+        assertThat(chatRoom.getClosedAt()).isNotNull(); // closedAt 세팅 확인
+        verify(eventPublisher).publishEvent(any(ChatSystemEvent.class)); // 이벤트 발행 확인
+    }
+
+    @Test
+    @DisplayName("담당 시니어가 아닌 다른 사람이 마감을 요청하면 예외가 발생한다.")
+    void closeChatRoom_Fail_Unauthorized() {
+        // given
+        Long roomId = 1L;
+        Long seniorId = 10L;
+        Long hackerId = 999L;
+
+        Member senior = mock(Member.class);
+        given(senior.getId()).willReturn(seniorId);
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .junior(mock(Member.class))
+                .senior(senior)
+                .build();
+
+        ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+        given(chatRoomRepository.findById(roomId)).willReturn(Optional.of(chatRoom));
+
+        // when & then
+        assertThrows(BusinessException.class, () -> {
+            chatRoomService.closeChatRoom(roomId, hackerId);
+        });
+    }
+}

--- a/src/test/java/com/knoc/event/listener/ChatEventListenerTest.java
+++ b/src/test/java/com/knoc/event/listener/ChatEventListenerTest.java
@@ -1,0 +1,75 @@
+package com.knoc.event.listener;
+
+import com.knoc.chat.dto.ChatMessageResponse;
+import com.knoc.chat.entity.ChatRoom;
+import com.knoc.chat.entity.ChatSystemEvent;
+import com.knoc.chat.entity.MessageType;
+import com.knoc.chat.repository.ChatMessageRepository;
+import com.knoc.chat.repository.ChatRoomRepository;
+import com.knoc.member.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatEventListenerTest {
+
+    @InjectMocks
+    private ChatEventListener chatEventListener;
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @ParameterizedTest
+    @EnumSource(value = MessageType.class, names = {
+            "ROOM_CLOSE",
+            "PAYMENT_REQUESTED",
+            "PAYMENT_COMPLETED",
+            "REPORT_COMPLETED",
+            "WORKSPACE_READY"
+    })
+    @DisplayName("다양한 시스템 이벤트가 발생해도 모두 DB에 저장하고 유저들에게 1:1 큐로 발송한다.")
+    void handleChatSystemEvent_Success_AllTypes(MessageType systemMessageType) {
+        // given
+        // 파라미터로 넘어온 systemMessageType을 사용합니다.
+        ChatSystemEvent event = new ChatSystemEvent(1L, systemMessageType, "시스템 알림 테스트", 12345L);
+
+        ChatRoom room = mock(ChatRoom.class);
+        Member junior = mock(Member.class);
+        Member senior = mock(Member.class);
+
+        given(chatRoomRepository.findById(1L)).willReturn(Optional.of(room));
+        given(room.getJunior()).willReturn(junior);
+        given(room.getSenior()).willReturn(senior);
+        given(junior.getEmail()).willReturn("junior@test.com");
+        given(senior.getEmail()).willReturn("senior@test.com");
+
+        // when
+        chatEventListener.handleChatEventSystem(event);
+
+        // then
+        // 1. DB에 해당 시스템 메시지가 정상적으로 저장되는지 확인
+        verify(chatMessageRepository).save(argThat(message ->
+                message.getMessageType() == systemMessageType
+        ));
+
+        // 2. 주니어와 시니어 양쪽 큐에 메시지가 발송되는지 확인 (총 2회)
+        verify(messagingTemplate, times(2))
+                .convertAndSendToUser(anyString(), eq("/queue/chat"), any(ChatMessageResponse.class));
+    }
+}


### PR DESCRIPTION
## 🔎 What

- 트랜잭션 격리 문제를 피하기 위해 @AfterEach에서 연관관계를 고려한 수동 데이터 클렌징을 구현
- jwtAuthenticationFilter에서 웹소켓 핸드셰이크 경로(/ws/**)를 제외하여, 일반 REST API 필터와 웹소켓 인터셉터 간의 인증 충돌을 해결
- HandshakeInterceptor에서 검증된 유저 정보를 웹소켓 세션의 Principal로 명시적으로 등록하도록 WebSocketConfig의 채널 인터셉터 로직을 수정
- DTO(ChatMessageRequest)에 Jackson 역직렬화를 위한 기본 생성자를 추가
- 채팅 서비스 단위 테스트 추가
- 채팅 도메인 통합 테스트 추가

## 🔗 Issue

- Closes: #73 

## ✅ 체크리스트

- [ ] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?

