### PR TITLE
[feat] 대시보드 후기 페이지 경로 수정, 1:1 채팅 로직 수정, 멘토링 인사이트 제거

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -231,14 +231,28 @@
 
         <!-- 시니어 카드 목록 -->
         <div class="row g-4" th:unless="${#lists.isEmpty(seniors)}">
+
+            <style>
+                .senior-card {
+                    cursor: pointer;
+                    border: 1px solid #333;
+                    transition: all 0.2s ease;
+                }
+                .senior-card:hover {
+                    border-color: #00CFE8 !important;
+                }
+                .senior-card:hover .btn-profile {
+                    background-color: #00CFE8 !important;
+                    border-color: #00CFE8 !important;
+                    color: #161b27 !important; /* 버튼 글자색을 어둡게 해 가독성 향상 */
+                }
+            </style>
+
             <div class="col-lg-4 col-md-6" th:each="senior : ${seniors}">
-                <div class="card card-dark h-100 text-white p-3 rounded-4"
-                     style="transition: border-color .2s;"
-                     onmouseover="this.style.borderColor='#00CFE8'"
-                     onmouseout="this.style.borderColor='#333'">
+                <div class="card card-dark h-100 text-white p-3 rounded-4 senior-card"
+                     th:onclick="'location.href=\'' + @{/senior/{id}(id=${senior.id})} + '\''">
                     <div class="card-body">
 
-                        <!-- 프로필 이미지 + 이름 -->
                         <div class="d-flex align-items-center gap-3 mb-3">
                             <img th:src="${senior.profileImageUrl != null ? senior.profileImageUrl : '/images/default-profile.png'}"
                                  alt="프로필"
@@ -256,17 +270,14 @@
                             </span>
                         </div>
 
-                        <!-- 직군 -->
                         <p class="text-mint small fw-semibold mb-2" th:text="${senior.position}">직군</p>
 
-                        <!-- 기술 스택 -->
                         <div class="mb-3 d-flex flex-wrap gap-1">
                             <span class="badge bg-secondary"
                                   th:each="skill : ${senior.skills}"
                                   th:text="${skill}"></span>
                         </div>
 
-                        <!-- 상세 소개 (최대 2줄) -->
                         <p class="text-light small"
                            style="min-height:48px; overflow:hidden; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical;"
                            th:text="${senior.introduction}"></p>
@@ -277,7 +288,7 @@
                             ₩ <span th:text="${#numbers.formatInteger(senior.pricePerReview, 0, 'COMMA')}">0</span>
                         </span>
                         <a th:href="@{/senior/{id}(id=${senior.id})}"
-                           class="btn btn-outline-light rounded-pill btn-sm px-3">멘토링 신청</a>
+                           class="btn btn-outline-light rounded-pill btn-sm px-3 btn-profile">프로필 상세 보기</a>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/my/dashboard/junior.html
+++ b/src/main/resources/templates/my/dashboard/junior.html
@@ -361,7 +361,7 @@
                     <span class="guide-tag-v2 guide-tag-purple">후기 / 사례</span>
                     <p class="guide-title-v2">다른 주니어들은 어떻게 성장했을까?</p>
                     <p class="guide-desc-v2">사수 없이 성장 정체를 겪던 주니어들이 Knoc.에서 받은 리뷰 후기를 확인해보세요.</p>
-                    <a href="/reviews" class="guide-btn-v2">다른 사람들 후기 보러가기 &nbsp;→</a>
+                    <a href="/reviews/posts" class="guide-btn-v2">다른 사람들 후기 보러가기 &nbsp;→</a>
                 </div>
             </div>
 

--- a/src/main/resources/templates/my/dashboard/senior.html
+++ b/src/main/resources/templates/my/dashboard/senior.html
@@ -519,13 +519,12 @@
     <div class="card-dark p-4 mb-4">
         <div class="section-header">
             <span class="section-header-icon">
-                <!-- 말풍선 SVG -->
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
                 </svg>
             </span>
             <h5 class="section-title">전체 멘토링 내역</h5>
-            <a href="#" class="section-more">전체 보기 →</a>
+            <a href="#" class="section-more" th:if="${senior.orders != null and senior.orders.size() > 5}">전체 보기 →</a>
         </div>
 
         <div th:if="${senior.orders == null or senior.orders.isEmpty()}" class="empty-state">
@@ -534,61 +533,62 @@
         </div>
 
         <div th:unless="${senior.orders == null or senior.orders.isEmpty()}">
-            <div th:each="order : ${senior.orders}" class="mentoring-item">
+            <th:block th:each="order, iterStat : ${senior.orders}">
+                <div class="mentoring-item" th:if="${iterStat.index < 5}">
 
-                <!-- 상태별 아이콘 아바타 (기존 글자 아바타 → 아이콘으로 교체, Thymeleaf 조건 유지) -->
-                <div th:if="${order.status.name() == 'PENDING'}" class="mentor-avatar-icon avatar-pending">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
-                    </svg>
-                </div>
-                <div th:if="${order.status.name() == 'PAID'}" class="mentor-avatar-icon avatar-paid">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
-                    </svg>
-                </div>
-                <div th:if="${order.status.name() == 'SETTLED'}" class="mentor-avatar-icon avatar-settled">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/>
-                    </svg>
-                </div>
-                <div th:if="${order.status.name() == 'CANCELLED'}" class="mentor-avatar-icon avatar-cancelled">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/>
-                    </svg>
-                </div>
-
-                <div class="mentor-info">
-                    <div class="mentor-name-row">
-                        <span class="mentor-name" th:text="${order.juniorNickname}">주니어닉네임</span>
-
-                        <span th:if="${order.status.name() == 'PENDING'}"   class="status-pill status-pending">결제 대기</span>
-                        <span th:if="${order.status.name() == 'PAID'}"      class="status-pill status-paid">리뷰 진행중</span>
-                        <span th:if="${order.status.name() == 'SETTLED'}"   class="status-pill status-settled">완료</span>
-                        <span th:if="${order.status.name() == 'CANCELLED'}" class="status-pill status-cancelled">취소됨</span>
+                    <div th:if="${order.status.name() == 'PENDING'}" class="mentor-avatar-icon avatar-pending">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+                        </svg>
                     </div>
-                    <div class="mentor-sub">
-                        <span th:if="${order.status.name() == 'PENDING'}">주니어의 결제를 기다리고 있어요</span>
-                        <span th:if="${order.status.name() == 'PAID'}">리뷰 작성을 시작해 주세요</span>
-                        <span th:if="${order.status.name() == 'SETTLED'}">리뷰가 완료되었습니다</span>
-                        <span th:if="${order.status.name() == 'CANCELLED'}">취소된 주문입니다</span>
+                    <div th:if="${order.status.name() == 'PAID'}" class="mentor-avatar-icon avatar-paid">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+                        </svg>
+                    </div>
+                    <div th:if="${order.status.name() == 'SETTLED'}" class="mentor-avatar-icon avatar-settled">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/>
+                        </svg>
+                    </div>
+                    <div th:if="${order.status.name() == 'CANCELLED'}" class="mentor-avatar-icon avatar-cancelled">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/>
+                        </svg>
+                    </div>
+
+                    <div class="mentor-info">
+                        <div class="mentor-name-row">
+                            <span class="mentor-name" th:text="${order.juniorNickname}">주니어닉네임</span>
+
+                            <span th:if="${order.status.name() == 'PENDING'}"   class="status-pill status-pending">결제 대기</span>
+                            <span th:if="${order.status.name() == 'PAID'}"      class="status-pill status-paid">리뷰 진행중</span>
+                            <span th:if="${order.status.name() == 'SETTLED'}"   class="status-pill status-settled">완료</span>
+                            <span th:if="${order.status.name() == 'CANCELLED'}" class="status-pill status-cancelled">취소됨</span>
+                        </div>
+                        <div class="mentor-sub">
+                            <span th:if="${order.status.name() == 'PENDING'}">주니어의 결제를 기다리고 있어요</span>
+                            <span th:if="${order.status.name() == 'PAID'}">리뷰 작성을 시작해 주세요</span>
+                            <span th:if="${order.status.name() == 'SETTLED'}">리뷰가 완료되었습니다</span>
+                            <span th:if="${order.status.name() == 'CANCELLED'}">취소된 주문입니다</span>
+                        </div>
+                    </div>
+
+                    <div class="d-flex align-items-center gap-2">
+                        <a th:if="${order.status.name() == 'PAID'}"
+                           th:href="@{|/orders/${order.orderId}|}"
+                           class="btn-action btn-action-mint">리뷰 시작하기 →</a>
+
+                        <span th:if="${order.status.name() == 'SETTLED' and order.hasReview}"
+                              class="text-mint small fw-semibold">✓ 후기 받음</span>
+                        <span th:if="${order.status.name() == 'SETTLED' and !order.hasReview}"
+                              class="text-secondary small">완료</span>
+
+                        <a th:href="@{|/orders/${order.orderId}|}"
+                           class="btn-action btn-action-outline">리포트 보기 →</a>
                     </div>
                 </div>
-
-                <div class="d-flex align-items-center gap-2">
-                    <a th:if="${order.status.name() == 'PAID'}"
-                       th:href="@{|/orders/${order.orderId}|}"
-                       class="btn-action btn-action-mint">리뷰 시작하기 →</a>
-
-                    <span th:if="${order.status.name() == 'SETTLED' and order.hasReview}"
-                          class="text-mint small fw-semibold">✓ 후기 받음</span>
-                    <span th:if="${order.status.name() == 'SETTLED' and !order.hasReview}"
-                          class="text-secondary small">완료</span>
-
-                    <a th:href="@{|/orders/${order.orderId}|}"
-                       class="btn-action btn-action-outline">리포트 보기 →</a>
-                </div>
-            </div>
+            </th:block>
         </div>
     </div>
 
@@ -688,27 +688,6 @@
                 </form>
             </div>
         </div>
-    </div>
-
-    <!-- ===== AI 멘토 인사이트 ===== -->
-    <div class="insight-card">
-        <div class="d-flex align-items-center">
-            <span class="insight-badge">AI</span>
-            <h5 class="section-title mb-0">멘토 인사이트</h5>
-        </div>
-        <p class="text-secondary small mt-2 mb-0" th:if="${senior.aiInsights == null or senior.aiInsights.isEmpty()}">
-            아직 충분한 데이터가 쌓이지 않아 인사이트를 제공할 수 없어요. 리뷰가 더 쌓이면 AI가 멘토링 패턴을 분석해드려요.
-        </p>
-
-        <ul class="insight-list" th:if="${senior.aiInsights != null and !senior.aiInsights.isEmpty()}">
-            <li th:each="insight : ${senior.aiInsights}" th:text="${insight}">인사이트 내용</li>
-        </ul>
-
-        <ul class="insight-list" th:unless="${senior.aiInsights != null and !senior.aiInsights.isEmpty()}" style="display:none;">
-            <li><strong>테스트 코드</strong>에 관한 피드백을 주시는 리뷰에서 긍정적인 평가를 가장 많이 받고 계세요.</li>
-            <li>주니어가 <strong>막히는 지점</strong>에서 자주 언급되는 개념을 놓치지 않고 짚어주신 점이 인상적이에요.</li>
-            <li>답변의 <strong>평균 반응 시간</strong>이 상위 10% 수준으로 빠릅니다.</li>
-        </ul>
     </div>
 
 </div>

--- a/src/main/resources/templates/senior/detail.html
+++ b/src/main/resources/templates/senior/detail.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
       layout:decorate="~{layout/default_layout}">
 <head>
     <title>시니어 상세 프로필 | Knoc.</title>
@@ -98,33 +99,6 @@
     <div class="row g-4">
 
         <div class="col-lg-8 d-flex flex-column gap-4">
-
-            <div class="card card-dark p-4 p-md-5 rounded-4">
-                <h5 class="fw-bold text-white mb-4 d-flex align-items-center gap-2">
-                    <span class="badge bg-mint text-dark">AI</span> 멘토링 인사이트
-                </h5>
-                <div class="d-flex flex-column gap-3">
-                    <div class="card-inner-dark p-4 rounded-4 d-flex gap-3 align-items-start">
-                        <i class="bi bi-circle-fill dot-pink mt-1" style="font-size: 8px;"></i>
-                        <p class="text-light mb-0 lh-lg">
-                            <strong class="text-white">에러 처리</strong> 관련 멘토링 요청이 최근 3주간 40% 증가했어요. 관련 아티클을 작성하면 매칭률이 높아질 수 있어요.
-                        </p>
-                    </div>
-                    <div class="card-inner-dark p-4 rounded-4 d-flex gap-3 align-items-start">
-                        <i class="bi bi-circle-fill dot-blue mt-1" style="font-size: 8px;"></i>
-                        <p class="text-light mb-0 lh-lg">
-                            후기에서 <strong class="text-white">'설명이 친절함'</strong> 태그가 가장 많이 달렸어요. 이 강점을 프로필에 강조해보세요.
-                        </p>
-                    </div>
-                    <div class="card-inner-dark p-4 rounded-4 d-flex gap-3 align-items-start">
-                        <i class="bi bi-circle-fill dot-yellow mt-1" style="font-size: 8px;"></i>
-                        <p class="text-light mb-0 lh-lg">
-                            평균 리뷰 응답 시간이 <strong class="text-white">1.2일</strong>로 상위 10% 시니어 수준이에요.
-                        </p>
-                    </div>
-                </div>
-            </div>
-
             <div class="card card-dark p-4 p-md-5 rounded-4">
                 <h5 class="fw-bold text-white mb-4 d-flex align-items-center gap-2">
                     상세 소개
@@ -143,12 +117,24 @@
                     결제 전 시니어와 1:1 채팅을 통해 본인의 고민을 나누고 리뷰 가능 여부를 먼저 조율해보세요.
                 </p>
 
-                <form th:action="@{/chat/rooms}" method="post" class="w-100">
+                <form th:action="@{/chat/rooms}" method="post" class="w-100" sec:authorize="hasRole('USER')">
                     <input type="hidden" name="seniorId" th:value="${senior.memberId}"/>
                     <button type="submit" class="btn btn-outline-light rounded-pill w-100 py-3 fw-bold fs-6 shadow-sm mb-3">
                         1:1 채팅으로 조율하기
                     </button>
                 </form>
+
+                <div class="w-100" sec:authorize="hasRole('SENIOR')">
+                    <button type="button" class="btn btn-secondary rounded-pill w-100 py-3 fw-bold fs-6 shadow-sm mb-3" style="opacity: 0.6; cursor: not-allowed;" disabled>
+                        주니어 회원만 신청 가능합니다
+                    </button>
+                </div>
+
+                <div class="w-100" sec:authorize="isAnonymous()">
+                    <a th:href="@{/login}" class="btn btn-outline-secondary rounded-pill w-100 py-3 fw-bold fs-6 shadow-sm mb-3">
+                        로그인 후 이용 가능합니다
+                    </a>
+                </div>
 
                 <div class="text-secondary small d-flex flex-column align-items-center gap-1 mt-2">
                     <span class="text-mint">채팅은 100% 무료입니다</span>

--- a/src/test/java/com/knoc/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/knoc/chat/service/ChatMessageServiceTest.java
@@ -61,7 +61,7 @@ public class ChatMessageServiceTest {
         given(junior.getId()).willReturn(10L);
         given(junior.getEmail()).willReturn(senderEmail);
         given(junior.getNickname()).willReturn("주니어닉네임");
-        
+
         given(senior.getEmail()).willReturn("senior@test.com");
 
         // 2. ChatRoom 생성 (ID 주입)


### PR DESCRIPTION
## 🔎 What

프론트엔드 UI/UX 개선 및 권한별 화면(View) 처리
 - 시니어 상세 페이지의 권한별 버튼 처리, 시니어 목록 카드의 반응성 향상, 그리고 대시보드 UI 최적화 작업을 진행

## 🔗 Issue

- Closes: #96 

## ✅ 체크리스트

- [ ] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?

