### PR TITLE
[feat] 워크스페이스 hasReviewRequest 제공 및 시니어 리포트/후기 용어·빈상태 UI 통일

### DIFF
--- a/src/main/java/com/knoc/global/exception/ErrorCode.java
+++ b/src/main/java/com/knoc/global/exception/ErrorCode.java
@@ -45,6 +45,11 @@ public enum ErrorCode {
     REVIEW_REQUEST_ALREADY_EXISTS(409, "이미 해당 주문에 대한 리뷰 요청서가 존재합니다."),
     REVIEW_REQUEST_NOT_ALLOWED(403, "결제 완료된 주문만 리뷰 요청서를 작성할 수 있습니다."),
 
+    // 리뷰 리포트 관련 (Review Report)
+    REVIEW_REQUEST_REQUIRED_FOR_REPORT(400, "리뷰 요청서가 제출된 경우에만 리포트를 작성할 수 있습니다."),
+    REVIEW_REPORT_ALREADY_EXISTS(409, "이미 해당 리뷰 요청서에 대한 리포트가 존재합니다."),
+    REVIEW_REPORT_NOT_FOUND(404, "리뷰 리포트가 존재하지 않습니다."),
+
     // 리뷰 관련 (Review)
     REVIEW_ALREADY_EXISTS(409, "이미 해당 주문에 대한 후기가 존재합니다."),
     REVIEW_NOT_ALLOWED(403, "결제 완료된 주문만 후기를 작성할 수 있습니다."),

--- a/src/main/java/com/knoc/workspace/WorkspaceController.java
+++ b/src/main/java/com/knoc/workspace/WorkspaceController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.security.Principal;
 import java.util.List;
 
-@Tag(name = "Workspace Controller", description = "주문/작업 공간 관련 기능(워크스페이스 조회, 보고서 작성, 정산, 피드백)")
+@Tag(name = "Workspace Controller", description = "워크스페이스(주문별 화면) 조회, 채팅 내역, 코드 리뷰 리포트, 멘토링 종료(정산), 주니어 후기")
 @Controller
 @RequiredArgsConstructor
 public class WorkspaceController {
@@ -41,7 +41,7 @@ public class WorkspaceController {
         return chatMessageService.getPreviousMessages(chatRoomId, before, principal.getName());
     }
 
-    @Operation(summary = "작업 보고서 제출", description = "시니어가 작업한 보고서를 제출합니다.")
+    @Operation(summary = "코드 리뷰 리포트 제출", description = "시니어가 해당 주문의 코드 리뷰 리포트를 제출합니다.")
     @PostMapping("/orders/{orderId}/report")
     @ResponseBody
     public ResponseEntity<Void> submitReport(@PathVariable Long orderId,
@@ -63,7 +63,7 @@ public class WorkspaceController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "리뷰/피드백 제출", description = "작업 완료 후 리뷰 및 피드백을 제출합니다.")
+    @Operation(summary = "후기 제출", description = "멘토링 종료 후 주니어가 후기를 제출합니다.")
     @PostMapping("/orders/{orderId}/feedback")
     @ResponseBody
     @PreAuthorize("hasRole('USER')")
@@ -74,14 +74,14 @@ public class WorkspaceController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "리뷰 정보 조회", description = "제출된 리뷰 및 피드백 정보를 조회합니다.")
-    @GetMapping("/orders/{orderId}/review")
+    @Operation(summary = "후기 조회", description = "제출된 후기(평점/코멘트) 정보를 조회합니다.")
+    @GetMapping("/orders/{orderId}/feedback")
     @ResponseBody
     public ReviewFeedbackResponse getReview(@PathVariable Long orderId, Principal principal) {
         return workspaceFacadeService.getReviewFeedback(orderId, principal.getName());
     }
 
-    @Operation(summary = "작업 보고서 수정", description = "이미 제출된 작업 보고서의 내용을 수정합니다.")
+    @Operation(summary = "코드 리뷰 리포트 수정", description = "이미 제출된 코드 리뷰 리포트의 내용을 수정합니다.")
     @PatchMapping("/orders/{orderId}/report")
     @ResponseBody
     public ResponseEntity<Void> updateReport(@PathVariable Long orderId,

--- a/src/main/java/com/knoc/workspace/WorkspaceDto.java
+++ b/src/main/java/com/knoc/workspace/WorkspaceDto.java
@@ -16,6 +16,7 @@ public record WorkspaceDto(
         String opponentNickname,
         String opponentAvatarUrl,
         List<ChatMessageResponse> initialMessages,
+        boolean hasReviewRequest,
         String githubPrUrl,
         String projectContext,
         String concernPoint,

--- a/src/main/java/com/knoc/workspace/WorkspaceFacadeService.java
+++ b/src/main/java/com/knoc/workspace/WorkspaceFacadeService.java
@@ -83,6 +83,7 @@ public class WorkspaceFacadeService {
                 chatMessageService.getPreviousMessages(chatRoomId, Long.MAX_VALUE, email);
 
         Optional<ReviewRequest> reviewRequestOpt = reviewRequestRepository.findByOrder(order);
+        boolean hasReviewRequest = reviewRequestOpt.isPresent();
         String githubPrUrl = reviewRequestOpt.map(ReviewRequest::getGithubPrUrl).orElse(null);
         String projectContext = reviewRequestOpt.map(ReviewRequest::getProjectContext).orElse(null);
         String concernPoint = reviewRequestOpt.map(ReviewRequest::getConcernPoint).orElse(null);
@@ -121,6 +122,7 @@ public class WorkspaceFacadeService {
                 .opponentNickname(opponent.getNickname())
                 .opponentAvatarUrl(opponent.getProfileImageUrl())
                 .initialMessages(initialMessages)
+                .hasReviewRequest(hasReviewRequest)
                 .githubPrUrl(githubPrUrl)
                 .projectContext(projectContext)
                 .concernPoint(concernPoint)

--- a/src/main/java/com/knoc/workspace/WorkspaceFacadeService.java
+++ b/src/main/java/com/knoc/workspace/WorkspaceFacadeService.java
@@ -151,10 +151,10 @@ public class WorkspaceFacadeService {
         }
 
         ReviewRequest reviewRequest = reviewRequestRepository.findByOrder(order)
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_REQUEST_REQUIRED_FOR_REPORT));
 
         if (reviewReportRepository.findByReviewRequest(reviewRequest).isPresent()) {
-            throw new BusinessException(ErrorCode.REVIEW_ALREADY_EXISTS);
+            throw new BusinessException(ErrorCode.REVIEW_REPORT_ALREADY_EXISTS);
         }
 
         reviewReportRepository.save(ReviewReport.builder()
@@ -191,10 +191,10 @@ public class WorkspaceFacadeService {
         }
 
         ReviewRequest reviewRequest = reviewRequestRepository.findByOrder(order)
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_REQUEST_REQUIRED_FOR_REPORT));
 
         ReviewReport report = reviewReportRepository.findByReviewRequest(reviewRequest)
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_REPORT_NOT_FOUND));
 
         report.update(industryPerspective, edgeCases, alternatives);
     }

--- a/src/main/resources/templates/workspace/workspace.html
+++ b/src/main/resources/templates/workspace/workspace.html
@@ -312,13 +312,18 @@
 
                 <!-- 변경 파일 탭 -->
                 <div id="tab-files" class="tab-panel active">
-                    <div th:if="${workspace.prMetadata == null}" class="empty-pr">
-                        <span style="font-size:2rem;">📂</span>
-                        <span th:text="${workspace.hasReviewRequest ? 'PR 파일 정보를 불러오지 못했습니다.' : '아직 제출된 리뷰 요청이 없습니다.'}"></span>
+                    <div th:if="${workspace.prMetadata == null}" class="report-waiting">
+                        <div class="waiting-icon">📂</div>
+                        <div class="waiting-title"
+                             th:text="${workspace.hasReviewRequest ? 'PR 파일 정보를 불러오지 못했습니다.' : '아직 제출된 리뷰 요청이 없습니다.'}"></div>
+                        <div class="waiting-desc"
+                             th:text="${workspace.hasReviewRequest ? '잠시 후 다시 시도하거나 GitHub PR 링크를 확인해 주세요.' : '주니어가 리뷰 요청서를 제출하면 변경 파일을 확인할 수 있습니다.'}"></div>
                     </div>
                     <th:block th:if="${workspace.prMetadata != null}">
-                        <div th:if="${#lists.isEmpty(workspace.prMetadata.files())}" class="empty-pr">
-                            <span>변경된 파일이 없습니다.</span>
+                        <div th:if="${#lists.isEmpty(workspace.prMetadata.files())}" class="report-waiting">
+                            <div class="waiting-icon">📄</div>
+                            <div class="waiting-title">변경된 파일이 없습니다</div>
+                            <div class="waiting-desc">PR에 포함된 변경 파일 목록이 비어 있습니다.</div>
                         </div>
                         <div th:each="file, iter : ${workspace.prMetadata.files()}"
                              class="file-card" th:id="'file-' + ${iter.index}">
@@ -338,8 +343,10 @@
 
                 <!-- 리뷰 요청 정보 탭 -->
                 <div id="tab-context" class="tab-panel">
-                    <div th:if="${!workspace.hasReviewRequest}" class="empty-pr">
-                        <span>아직 제출된 리뷰 요청이 없습니다.</span>
+                    <div th:if="${!workspace.hasReviewRequest}" class="report-waiting">
+                        <div class="waiting-icon">📁</div>
+                        <div class="waiting-title">아직 제출된 리뷰 요청이 없습니다</div>
+                        <div class="waiting-desc">주니어가 리뷰 요청서를 제출하면 이 탭에서 확인할 수 있습니다.</div>
                     </div>
                     <th:block th:if="${workspace.hasReviewRequest}">
                         <div class="section-card">

--- a/src/main/resources/templates/workspace/workspace.html
+++ b/src/main/resources/templates/workspace/workspace.html
@@ -964,7 +964,7 @@
 
         // ── 후기 보기 모달 ──
         function openReviewModal(reviewOrderId) {
-            fetch('/orders/' + reviewOrderId + '/review')
+            fetch('/orders/' + reviewOrderId + '/feedback')
                 .then(function(r) { if (!r.ok) throw new Error('fetch'); return r.json(); })
                 .then(function(data) {
                     document.querySelectorAll('#reviewStarRow .star').forEach(function(s) {

--- a/src/main/resources/templates/workspace/workspace.html
+++ b/src/main/resources/templates/workspace/workspace.html
@@ -280,7 +280,7 @@
         <div class="pr-pane">
             <div class="pr-header">
                 <div class="pr-title"
-                     th:text="${workspace.prMetadata != null ? workspace.prMetadata.title() : (workspace.githubPrUrl != null ? 'PR 정보를 불러올 수 없습니다' : '리뷰 요청이 없습니다')}">
+                     th:text="${workspace.prMetadata != null ? workspace.prMetadata.title() : (workspace.hasReviewRequest ? 'PR 정보를 불러올 수 없습니다' : '리뷰 요청이 없습니다')}">
                 </div>
                 <div class="pr-meta" th:if="${workspace.prMetadata != null}">
                     <span th:class="'pr-badge badge-' + ${workspace.prMetadata.state()}"
@@ -314,7 +314,7 @@
                 <div id="tab-files" class="tab-panel active">
                     <div th:if="${workspace.prMetadata == null}" class="empty-pr">
                         <span style="font-size:2rem;">📂</span>
-                        <span th:text="${workspace.githubPrUrl != null ? 'PR 파일 정보를 불러오지 못했습니다.' : '아직 제출된 리뷰 요청이 없습니다.'}"></span>
+                        <span th:text="${workspace.hasReviewRequest ? 'PR 파일 정보를 불러오지 못했습니다.' : '아직 제출된 리뷰 요청이 없습니다.'}"></span>
                     </div>
                     <th:block th:if="${workspace.prMetadata != null}">
                         <div th:if="${#lists.isEmpty(workspace.prMetadata.files())}" class="empty-pr">
@@ -338,16 +338,16 @@
 
                 <!-- 리뷰 요청 정보 탭 -->
                 <div id="tab-context" class="tab-panel">
-                    <div th:if="${workspace.projectContext == null}" class="empty-pr">
+                    <div th:if="${!workspace.hasReviewRequest}" class="empty-pr">
                         <span>아직 제출된 리뷰 요청이 없습니다.</span>
                     </div>
-                    <th:block th:if="${workspace.projectContext != null}">
+                    <th:block th:if="${workspace.hasReviewRequest}">
                         <div class="section-card">
-                            <div class="section-label">프로젝트 컨텍스트</div>
+                            <div class="section-label">프로젝트 배경/비즈니스 로직</div>
                             <div class="section-text" th:text="${workspace.projectContext}"></div>
                         </div>
                         <div class="section-card">
-                            <div class="section-label">궁금한 점 / 우려 사항</div>
+                            <div class="section-label">질문/고민 포인트</div>
                             <div class="section-text" th:text="${workspace.concernPoint}"></div>
                         </div>
                     </th:block>
@@ -425,7 +425,8 @@
                         <div class="waiting-desc">리뷰가 완료되면 이 탭에서 확인할 수 있습니다.</div>
                     </div>
 
-                    <div th:if="${!workspace.hasReport and workspace.isSenior}">
+                    <!-- 시니어 리포트 작성: 리뷰 요청서가 제출된 경우에만 폼 노출 -->
+                    <div th:if="${!workspace.hasReport and workspace.isSenior and workspace.hasReviewRequest}">
                         <form id="reportForm" th:attr="data-action=@{/orders/{id}/report(id=${workspace.orderId})}" class="report-form">
                             <div class="form-group">
                                 <label class="form-label">현업 관점 <span class="form-hint">현장에서 이런 코드를 봤을 때 어떤 인상을 받는지 솔직하게 작성해 주세요.</span></label>
@@ -441,6 +442,13 @@
                             </div>
                             <button type="submit" class="btn-submit-report">리뷰 제출하기</button>
                         </form>
+                    </div>
+
+                    <!-- 시니어: 리뷰 요청서가 없는 경우 리포트 작성 폼을 막고 안내만 노출 -->
+                    <div th:if="${!workspace.hasReport and workspace.isSenior and !workspace.hasReviewRequest}" class="report-waiting">
+                        <div class="waiting-icon">📁</div>
+                        <div class="waiting-title">아직 제출된 리뷰 요청이 없습니다</div>
+                        <div class="waiting-desc">주니어가 리뷰 요청서를 제출하면 리포트를 작성할 수 있습니다.</div>
                     </div>
 
                 </div>


### PR DESCRIPTION
## 🔎 What

- 워크스페이스(/orders/{orderId})에서 리뷰 요청서(ReviewRequest)가 제출되지 않은 상태라면, 시니어 리포트 작성 UI가 노출되지 않도록 하기 위해 백엔드에서 hasReviewRequest 상태를 내려줌
- 리뷰 리포트  관련 에러코드 추가 후 적용
- WorkspaceController의 swagger 문구 용어 통일
- 리뷰 요청서가 작성되지 않았거나 PR에 변경된 파일이 없을 경우 워크스페이스 각 탭(변경 파일, 리뷰 요청 정보, 시니어 리포트)의 문구/스타일을 통일

## 🔗 Issue

- Closes: #124 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?

