### PR TITLE
[feat] 멘토링 후기 페이지에 '나의 후기' 탭 추가

### DIFF
--- a/src/main/java/com/knoc/global/exception/ErrorCode.java
+++ b/src/main/java/com/knoc/global/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     INVALID_IDEMPOTENCY_KEY(400, "유효하지 않은 멱등성 키입니다."),
     ORDER_INVALID_AMOUNT(400, "유효하지 않은 결제 금액입니다."),
     ORDER_INVALID_ORDER_NUMBER(400, "유효하지 않은 주문번호입니다."),
+    ORDER_CANNOT_BE_SETTLED(400, "현재 주문 상태에서는 정산을 진행할 수 없습니다."),
 
     // 리뷰 요청서 관련 (Review Request)
     REVIEW_REQUEST_ALREADY_EXISTS(409, "이미 해당 주문에 대한 리뷰 요청서가 존재합니다."),

--- a/src/main/java/com/knoc/global/exception/ErrorCode.java
+++ b/src/main/java/com/knoc/global/exception/ErrorCode.java
@@ -54,6 +54,8 @@ public enum ErrorCode {
     // 리뷰 관련 (Review)
     REVIEW_ALREADY_EXISTS(409, "이미 해당 주문에 대한 후기가 존재합니다."),
     REVIEW_NOT_ALLOWED(403, "결제 완료된 주문만 후기를 작성할 수 있습니다."),
+    REVIEW_NOT_FOUND(404, "해당 주문에 대한 후기가 존재하지 않습니다."),
+    REVIEW_UPDATE_NOT_ALLOWED(403, "후기를 수정할 권한이 없습니다."),
 
     // GitHub 관련 (Github)
     GITHUB_PR_NOT_FOUND(404, "존재하지 않는 PR이거나 접근 권한이 없습니다."),

--- a/src/main/java/com/knoc/order/service/OrderService.java
+++ b/src/main/java/com/knoc/order/service/OrderService.java
@@ -280,7 +280,7 @@ public class OrderService {
             throw new BusinessException(ErrorCode.NOT_JUNIOR_FOR_ORDER);
         }
         if (order.getStatus() != OrderStatus.PAID) {
-            throw new BusinessException(ErrorCode.ORDER_CANNOT_BE_PAID);
+            throw new BusinessException(ErrorCode.ORDER_CANNOT_BE_SETTLED);
         }
 
         order.updateStatus(OrderStatus.SETTLED);
@@ -296,7 +296,7 @@ public class OrderService {
         eventPublisher.publishEvent(new ChatSystemEvent(
                 order.getChatRoom().getId(),
                 MessageType.ROOM_CLOSE,
-                MessageType.ROOM_CLOSE.getTemplate(),
+                null,
                 null
         ));
     }

--- a/src/main/java/com/knoc/reviewFeedback/controller/ReviewFeedbackController.java
+++ b/src/main/java/com/knoc/reviewFeedback/controller/ReviewFeedbackController.java
@@ -1,5 +1,6 @@
 package com.knoc.reviewFeedback.controller;
 
+import com.knoc.reviewFeedback.dto.MyReviewPageResponse;
 import com.knoc.reviewFeedback.dto.ReviewPageDto;
 import com.knoc.reviewFeedback.service.ReviewFeedbackService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.security.Principal;
 
 @Tag(name = "Review-Page-Controller", description = "멘토링 후기 공개 페이지")
 @Controller
@@ -26,5 +30,12 @@ public class ReviewFeedbackController {
         model.addAttribute("totalCount", page.getTotalCount());
         model.addAttribute("topSeniors", page.getTopSeniors());
         return "review/posts";
+    }
+
+    @Operation(summary = "나의 멘토링 후기 목록 카드", description = "내가 작성한 후기 카드를 최신순으로 조회합니다.")
+    @GetMapping("/posts/me")
+    @ResponseBody
+    public MyReviewPageResponse myReviews(Principal principal) {
+        return reviewFeedbackService.getMyReviewCards(principal.getName());
     }
 }

--- a/src/main/java/com/knoc/reviewFeedback/dto/MyReviewPageResponse.java
+++ b/src/main/java/com/knoc/reviewFeedback/dto/MyReviewPageResponse.java
@@ -1,0 +1,11 @@
+package com.knoc.reviewFeedback.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public record MyReviewPageResponse(List<ReviewPageDto.ReviewCardDto> myReviews, int totalCount) {
+    @Builder
+    public MyReviewPageResponse {
+    }
+}

--- a/src/main/java/com/knoc/reviewFeedback/dto/ReviewPageDto.java
+++ b/src/main/java/com/knoc/reviewFeedback/dto/ReviewPageDto.java
@@ -23,6 +23,7 @@ public class ReviewPageDto {
         private final String timeAgo;
         private final byte rating;
         private final String content;
+        private final Long orderId;
     }
 
     @Getter

--- a/src/main/java/com/knoc/reviewFeedback/entity/ReviewFeedback.java
+++ b/src/main/java/com/knoc/reviewFeedback/entity/ReviewFeedback.java
@@ -57,4 +57,9 @@ public class ReviewFeedback {
         this.rating = rating;
         this.comment = comment;
     }
+
+    public void update(byte rating, String comment) {
+        this.rating = rating;
+        this.comment = comment;
+    }
 }

--- a/src/main/java/com/knoc/reviewFeedback/repository/ReviewFeedbackRepository.java
+++ b/src/main/java/com/knoc/reviewFeedback/repository/ReviewFeedbackRepository.java
@@ -26,4 +26,6 @@ public interface ReviewFeedbackRepository extends JpaRepository<ReviewFeedback,L
 
     @Query("SELECT r.seniorProfile FROM ReviewFeedback r WHERE r.createdAt >= :startOfMonth GROUP BY r.seniorProfile ORDER BY COUNT(r) DESC")
     List<SeniorProfile> findTop3ActiveSeniorsThisMonth(@Param("startOfMonth") LocalDateTime startOfMonth, org.springframework.data.domain.Pageable pageable);
+
+    List<ReviewFeedback> findByJunior_IdOrderByCreatedAtDesc(Long juniorId);
 }

--- a/src/main/java/com/knoc/reviewFeedback/service/ReviewFeedbackService.java
+++ b/src/main/java/com/knoc/reviewFeedback/service/ReviewFeedbackService.java
@@ -94,6 +94,7 @@ public class ReviewFeedbackService {
                 .timeAgo(timeAgo(r.getCreatedAt()))
                 .rating(r.getRating())
                 .content(r.getComment())
+                .orderId(r.getOrder().getId())
                 .build()
         ).toList();
     }

--- a/src/main/java/com/knoc/reviewFeedback/service/ReviewFeedbackService.java
+++ b/src/main/java/com/knoc/reviewFeedback/service/ReviewFeedbackService.java
@@ -70,6 +70,19 @@ public class ReviewFeedbackService {
 
     }
 
+    @Transactional
+    public void updateReview(Long orderId, ReviewFeedbackRequestDto dto, Long juniorId) {
+        ReviewFeedback feedback = reviewFeedbackRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+
+        if (!feedback.getJunior().getId().equals(juniorId)) {
+            throw new BusinessException(ErrorCode.REVIEW_UPDATE_NOT_ALLOWED);
+        }
+
+        // rating/comment validation은 DTO(@Min/@Max) + 컨트롤러 @Valid에서 처리된다는 전제
+        feedback.update(dto.getRating(), dto.getComment());
+    }
+
     public ReviewPageDto getReviewPage() {
         List<ReviewFeedback> feedbacks = reviewFeedbackRepository.findAllByOrderByCreatedAtDesc();
 

--- a/src/main/java/com/knoc/reviewFeedback/service/ReviewFeedbackService.java
+++ b/src/main/java/com/knoc/reviewFeedback/service/ReviewFeedbackService.java
@@ -2,9 +2,12 @@ package com.knoc.reviewFeedback.service;
 
 import com.knoc.global.exception.BusinessException;
 import com.knoc.global.exception.ErrorCode;
+import com.knoc.member.Member;
+import com.knoc.member.MemberRepository;
 import com.knoc.order.entity.Order;
 import com.knoc.order.entity.OrderStatus;
 import com.knoc.order.repository.OrderRepository;
+import com.knoc.reviewFeedback.dto.MyReviewPageResponse;
 import com.knoc.reviewFeedback.dto.ReviewPageDto;
 import com.knoc.senior.entity.SeniorProfile;
 import com.knoc.senior.repository.SeniorProfileRepository;
@@ -29,6 +32,7 @@ public class ReviewFeedbackService {
     private final ReviewFeedbackRepository reviewFeedbackRepository;
     private final OrderRepository orderRepository;
     private final SeniorProfileRepository seniorProfileRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public void createReview(ReviewFeedbackRequestDto dto, Long juniorId) {
@@ -112,4 +116,12 @@ public class ReviewFeedbackService {
         return (days / 30) + "개월 전";
     }
 
+    public MyReviewPageResponse getMyReviewCards(String email) {
+        Long juniorId = memberRepository.findByEmail(email)
+                .map(Member::getId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<ReviewFeedback> myFeedbacks = reviewFeedbackRepository.findByJunior_IdOrderByCreatedAtDesc(juniorId);
+        return new MyReviewPageResponse(mapToCards(myFeedbacks), myFeedbacks.size());
+    }
 }

--- a/src/main/java/com/knoc/workspace/WorkspaceController.java
+++ b/src/main/java/com/knoc/workspace/WorkspaceController.java
@@ -25,9 +25,13 @@ public class WorkspaceController {
 
     @Operation(summary = "워크스페이스 페이지 조회", description = "해당 주문(orderId)에 대한 워크스페이스 화면을 렌더링합니다.")
     @GetMapping("/orders/{orderId}")
-    public String workspace(@PathVariable Long orderId, Principal principal, Model model) {
+    public String workspace(@PathVariable Long orderId,
+                            @RequestParam(value = "reviewOnly", required = false) String reviewOnly,
+                            Principal principal,
+                            Model model) {
         WorkspaceDto dto = workspaceFacadeService.getWorkspaceData(orderId, principal.getName());
         model.addAttribute("workspace", dto);
+        model.addAttribute("openReviewOnlyModal", "1".equals(reviewOnly) || "true".equalsIgnoreCase(reviewOnly));
         return "workspace/workspace";
     }
 

--- a/src/main/java/com/knoc/workspace/WorkspaceController.java
+++ b/src/main/java/com/knoc/workspace/WorkspaceController.java
@@ -78,6 +78,17 @@ public class WorkspaceController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "후기 수정", description = "주니어가 이미 작성한 후기를 수정합니다.")
+    @PatchMapping("/orders/{orderId}/feedback")
+    @ResponseBody
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<Void> updateFeedback(@PathVariable Long orderId,
+                                               @RequestBody ReviewFeedbackRequestDto dto,
+                                               Principal principal) {
+        workspaceFacadeService.updateFeedback(orderId, principal.getName(), dto);
+        return ResponseEntity.ok().build();
+    }
+
     @Operation(summary = "후기 조회", description = "제출된 후기(평점/코멘트) 정보를 조회합니다.")
     @GetMapping("/orders/{orderId}/feedback")
     @ResponseBody

--- a/src/main/java/com/knoc/workspace/WorkspaceFacadeService.java
+++ b/src/main/java/com/knoc/workspace/WorkspaceFacadeService.java
@@ -222,6 +222,13 @@ public class WorkspaceFacadeService {
         ));
     }
 
+    @Transactional
+    public void updateFeedback(Long orderId, String email, ReviewFeedbackRequestDto dto) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        reviewFeedbackService.updateReview(orderId, dto, member.getId());
+    }
+
     @Transactional(readOnly = true)
     public ReviewFeedbackResponse getReviewFeedback(Long orderId, String email) {
         Order order = orderRepository.findById(orderId)

--- a/src/main/resources/templates/my/dashboard/junior.html
+++ b/src/main/resources/templates/my/dashboard/junior.html
@@ -211,6 +211,7 @@
             display: inline-flex;
             align-items: center;
             gap: 0.3rem;
+            text-decoration: none;
         }
         .btn-action-outline {
             background-color: transparent;
@@ -434,7 +435,7 @@
                 <!-- 액션 -->
                 <div class="d-flex align-items-center gap-2">
                     <a th:if="${order.status.name() == 'SETTLED' and !order.hasReview}"
-                       th:href="@{|/reviews/orders/${order.orderId}/new|}"
+                       th:href="@{|/orders/${order.orderId}?reviewOnly=1|}"
                        class="btn-action btn-action-mint">✎ 후기 작성하기</a>
 
                     <span th:if="${order.status.name() == 'SETTLED' and order.hasReview}"

--- a/src/main/resources/templates/review/posts.html
+++ b/src/main/resources/templates/review/posts.html
@@ -272,21 +272,21 @@
                                     <span th:class="${(i - 0.5) <= review.rating} ? 'star-filled' : 'star-empty'">★</span>
                                 </th:block>
                             </div>
-                            <!-- JS가 '내 후기'에만 표시하도록 토글 -->
-                            <a href="#"
-                               class="btn btn-sm btn-outline-secondary rounded-pill px-2 d-none edit-review-link"
-                               style="font-size:0.78rem; color:#8b93a7; border-color:#2a2f40;"
-                               title="후기 수정"
-                               aria-label="후기 수정"
-                               th:attr="data-order-id=${review.orderId}">
-                                ✎
-                            </a>
                         </div>
                     </div>
                     <p class="review-body" th:text="${review.content}"></p>
-                    <div class="d-flex justify-content-end mt-3">
+                    <div class="d-flex align-items-center mt-3">
+                        <!-- JS가 '내 후기'에만 표시하도록 토글 -->
+                        <a th:href="@{|/orders/${review.orderId}?reviewOnly=1|}"
+                           class="btn btn-sm btn-outline-secondary rounded-pill px-2 d-none edit-review-link"
+                           style="font-size:0.78rem; color:#8b93a7; border-color:#2a2f40;"
+                           title="후기 수정"
+                           aria-label="후기 수정"
+                           th:attr="data-order-id=${review.orderId}">
+                            ✎
+                        </a>
                         <a th:href="@{/senior/{id}(id=${review.seniorProfileId})}"
-                           class="btn btn-sm btn-outline-secondary rounded-pill px-3"
+                           class="btn btn-sm btn-outline-secondary rounded-pill px-3 ms-auto"
                            style="font-size:0.78rem; color:#8b93a7; border-color:#2a2f40;">
                             멘토 프로필 보기 →
                         </a>
@@ -527,22 +527,22 @@
 
                             <div class="d-flex align-items-center gap-2">
                                 <div class="star-row mt-1">${starsHtml(review.rating)}</div>
-                                <a href="#"
-                                   class="btn btn-sm btn-outline-secondary rounded-pill px-2 edit-review-link"
-                                   style="font-size:0.78rem; color:#8b93a7; border-color:#2a2f40;"
-                                   title="후기 수정"
-                                   aria-label="후기 수정"
-                                   data-order-id="${escapeHtml(String(orderId))}">
-                                    ✎
-                                </a>
                             </div>
                         </div>
 
                         <p class="review-body">${content}</p>
 
-                        <div class="d-flex justify-content-end mt-3">
+                        <div class="d-flex align-items-center mt-3">
+                            <a href="/orders/${encodeURIComponent(orderId)}?reviewOnly=1"
+                               class="btn btn-sm btn-outline-secondary rounded-pill px-2 edit-review-link"
+                               style="font-size:0.78rem; color:#8b93a7; border-color:#2a2f40;"
+                               title="후기 수정"
+                               aria-label="후기 수정"
+                               data-order-id="${escapeHtml(String(orderId))}">
+                                ✎
+                            </a>
                             <a href="/senior/${seniorProfileId}"
-                               class="btn btn-sm btn-outline-secondary rounded-pill px-3"
+                               class="btn btn-sm btn-outline-secondary rounded-pill px-3 ms-auto"
                                style="font-size:0.78rem; color:#8b93a7; border-color:#2a2f40;">
                                 멘토 프로필 보기 →
                             </a>

--- a/src/main/resources/templates/review/posts.html
+++ b/src/main/resources/templates/review/posts.html
@@ -236,14 +236,18 @@
 
             <!-- 필터 탭 -->
             <div class="filter-tab-bar">
-                <a href="#" class="filter-tab active">
+                <a href="#" class="filter-tab active" id="tabAllReviews">
                     전체
-                    <span class="tab-count" th:text="${totalCount != null ? totalCount : 4}">4</span>
+                    <span class="tab-count" id="tabAllCount" th:text="${totalCount != null ? totalCount : 4}">4</span>
+                </a>
+                <a href="#" class="filter-tab" id="tabMyReviews">
+                    나의 후기
+                    <span class="tab-count" id="tabMyCount">0</span>
                 </a>
             </div>
 
             <!-- 후기 목록 -->
-            <div class="d-flex flex-column gap-3">
+            <div class="d-flex flex-column gap-3" id="reviewList">
 
                 <!-- ── 동적 렌더링 ── -->
                 <div th:each="review : ${reviews}" class="review-card">
@@ -262,10 +266,21 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="star-row mt-1">
-                            <th:block th:each="i : ${#numbers.sequence(1, 5)}">
-                                <span th:class="${(i - 0.5) <= review.rating} ? 'star-filled' : 'star-empty'">★</span>
-                            </th:block>
+                        <div class="d-flex align-items-center gap-2">
+                            <div class="star-row mt-1">
+                                <th:block th:each="i : ${#numbers.sequence(1, 5)}">
+                                    <span th:class="${(i - 0.5) <= review.rating} ? 'star-filled' : 'star-empty'">★</span>
+                                </th:block>
+                            </div>
+                            <!-- JS가 '내 후기'에만 표시하도록 토글 -->
+                            <a href="#"
+                               class="btn btn-sm btn-outline-secondary rounded-pill px-2 d-none edit-review-link"
+                               style="font-size:0.78rem; color:#8b93a7; border-color:#2a2f40;"
+                               title="후기 수정"
+                               aria-label="후기 수정"
+                               th:attr="data-order-id=${review.orderId}">
+                                ✎
+                            </a>
                         </div>
                     </div>
                     <p class="review-body" th:text="${review.content}"></p>
@@ -434,6 +449,183 @@
             </div>
         </div>
     </div>
+
+    <script>
+    (function () {
+        const tabAll = document.getElementById('tabAllReviews');
+        const tabMy = document.getElementById('tabMyReviews');
+        const tabMyCount = document.getElementById('tabMyCount');
+        const reviewList = document.getElementById('reviewList');
+
+        if (!tabAll || !tabMy || !reviewList) return;
+
+        const initialAllHtml = reviewList.innerHTML;
+        let myCache = null; // { myReviews: [], totalCount: number }
+
+        function setActiveTab(active) {
+            tabAll.classList.toggle('active', active === 'all');
+            tabMy.classList.toggle('active', active === 'my');
+        }
+
+        function escapeHtml(str) {
+            return (str ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
+        function starsHtml(rating) {
+            const r = Number(rating || 0);
+            let html = '';
+            for (let i = 1; i <= 5; i++) {
+                html += `<span class="${(i - 0.5) <= r ? 'star-filled' : 'star-empty'}">★</span>`;
+            }
+            return html;
+        }
+
+        function renderEmptyMyReviews() {
+            reviewList.innerHTML = `
+                <div class="review-card">
+                    <p class="review-body mb-0" style="color:#8b93a7;">아직 작성한 후기가 없어요.</p>
+                </div>
+            `;
+        }
+
+        function renderMyReviews(myReviews) {
+            if (!Array.isArray(myReviews) || myReviews.length === 0) {
+                renderEmptyMyReviews();
+                return;
+            }
+
+            reviewList.innerHTML = myReviews.map(function (review) {
+                const juniorName = escapeHtml(review.juniorName || '');
+                const seniorName = escapeHtml(review.seniorName || '');
+                const mentoringType = escapeHtml(review.mentoringType || '');
+                const timeAgo = escapeHtml(review.timeAgo || '');
+                const content = escapeHtml(review.content || '');
+                const seniorProfileId = encodeURIComponent(review.seniorProfileId ?? '');
+                const orderId = review.orderId ?? '';
+
+                return `
+                    <div class="review-card">
+                        <div class="d-flex align-items-start justify-content-between mb-3">
+                            <div class="d-flex align-items-center gap-3">
+                                <div class="reviewer-avatar">${juniorName ? juniorName.substring(0, 1) : '나'}</div>
+                                <div>
+                                    <div class="reviewer-name">${juniorName || '나의 후기'}</div>
+                                    <div class="reviewer-meta">
+                                        <span>${seniorName}</span>
+                                        <span class="sep">·</span>
+                                        <span>${mentoringType}</span>
+                                        <span class="sep">·</span>
+                                        <span>${timeAgo}</span>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="d-flex align-items-center gap-2">
+                                <div class="star-row mt-1">${starsHtml(review.rating)}</div>
+                                <a href="#"
+                                   class="btn btn-sm btn-outline-secondary rounded-pill px-2 edit-review-link"
+                                   style="font-size:0.78rem; color:#8b93a7; border-color:#2a2f40;"
+                                   title="후기 수정"
+                                   aria-label="후기 수정"
+                                   data-order-id="${escapeHtml(String(orderId))}">
+                                    ✎
+                                </a>
+                            </div>
+                        </div>
+
+                        <p class="review-body">${content}</p>
+
+                        <div class="d-flex justify-content-end mt-3">
+                            <a href="/senior/${seniorProfileId}"
+                               class="btn btn-sm btn-outline-secondary rounded-pill px-3"
+                               style="font-size:0.78rem; color:#8b93a7; border-color:#2a2f40;">
+                                멘토 프로필 보기 →
+                            </a>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+        }
+
+        async function loadMyReviews() {
+            if (myCache) return myCache;
+
+            const res = await fetch('/reviews/posts/me', {
+                method: 'GET',
+                headers: { 'Accept': 'application/json' }
+            });
+            if (!res.ok) throw new Error('fetch my reviews failed');
+            myCache = await res.json();
+            return myCache;
+        }
+
+        async function prefetchMyReviews() {
+            try {
+                const data = await loadMyReviews();
+                if (tabMyCount && typeof data?.totalCount !== 'undefined') {
+                    tabMyCount.textContent = String(data.totalCount);
+                }
+                applyEditableToAll();
+            } catch (e) {
+                // 로그인 전/권한 없음/네트워크 오류 등은 조용히 무시 (초기값 0 유지)
+            }
+        }
+
+        function applyEditableToAll() {
+            if (!myCache || !Array.isArray(myCache.myReviews)) return;
+            const editableOrderIds = new Set(
+                myCache.myReviews
+                    .map(r => r && r.orderId)
+                    .filter(v => v !== null && typeof v !== 'undefined')
+                    .map(v => String(v))
+            );
+
+            document.querySelectorAll('.edit-review-link[data-order-id]').forEach(function (el) {
+                const orderId = el.getAttribute('data-order-id');
+                if (orderId && editableOrderIds.has(String(orderId))) {
+                    el.classList.remove('d-none');
+                } else {
+                    el.classList.add('d-none');
+                }
+            });
+        }
+
+        tabAll.addEventListener('click', function (e) {
+            e.preventDefault();
+            setActiveTab('all');
+            reviewList.innerHTML = initialAllHtml;
+            applyEditableToAll();
+        });
+
+        tabMy.addEventListener('click', async function (e) {
+            e.preventDefault();
+            setActiveTab('my');
+
+            try {
+                const data = await loadMyReviews();
+                if (tabMyCount && typeof data?.totalCount !== 'undefined') {
+                    tabMyCount.textContent = String(data.totalCount);
+                }
+                renderMyReviews(data?.myReviews || []);
+                applyEditableToAll();
+            } catch (err) {
+                reviewList.innerHTML = `
+                    <div class="review-card">
+                        <p class="review-body mb-0" style="color:#8b93a7;">나의 후기를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.</p>
+                    </div>
+                `;
+            }
+        });
+
+        // 페이지 진입 시 '나의 후기' count/수정 링크를 미리 동기화
+        prefetchMyReviews();
+    })();
+    </script>
 
 </div>
 </html>

--- a/src/main/resources/templates/workspace/workspace.html
+++ b/src/main/resources/templates/workspace/workspace.html
@@ -806,6 +806,7 @@
         function closeConfirmModal() {
             document.getElementById('confirmModal').style.display = 'none';
             document.getElementById('confirmModal').removeAttribute('data-review-only');
+            document.getElementById('confirmModal').removeAttribute('data-review-edit');
         }
 
         function onBackdropClick(e) { if (e.target === document.getElementById('confirmModal')) closeConfirmModal(); }
@@ -816,6 +817,7 @@
             btnOnly.style.display = ''; btnOnly.disabled = false; btnOnly.textContent = '후기 없이 멘토링 종료하기';
             btnReview.disabled = false; btnReview.textContent = '멘토링 종료 및 정산 완료';
             document.getElementById('confirmModal').removeAttribute('data-review-only');
+            document.getElementById('confirmModal').removeAttribute('data-review-edit');
         }
 
         function updateStars(val) {
@@ -832,6 +834,7 @@
 
         function doSettle(withReview) {
             const isReviewOnly = document.getElementById('confirmModal').getAttribute('data-review-only') === 'true';
+            const isReviewEdit = document.getElementById('confirmModal').getAttribute('data-review-edit') === 'true';
             if (withReview && selectedRating === 0) { alert('별점을 선택해 주세요.'); return; }
             const btnOnly   = document.getElementById('btnSettleOnly');
             const btnReview = document.getElementById('btnSettleReview');
@@ -844,7 +847,8 @@
             const chain = withReview
                 ? settlePromise.then(function() {
                     return fetch('/orders/' + orderId + '/feedback', {
-                        method: 'POST', headers: { 'Content-Type': 'application/json' },
+                        method: (isReviewOnly && isReviewEdit) ? 'PATCH' : 'POST',
+                        headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ orderId: orderId, rating: selectedRating, comment: comment || null })
                     }).then(function(r) { if (!r.ok) throw new Error('review'); });
                 })
@@ -1001,7 +1005,22 @@
         // query param으로 진입 시 후기 모달 자동 오픈
         const openReviewOnlyModalOnLoad = /*[[${openReviewOnlyModal}]]*/ false;
         if (openReviewOnlyModalOnLoad) {
-            try { openReviewOnlyModal(); } catch (e) {}
+            try {
+                openReviewOnlyModal();
+                const hasReviewOnLoad = /*[[${workspace.hasReview}]]*/ false;
+                if (hasReviewOnLoad) {
+                    fetch('/orders/' + orderId + '/feedback', { method: 'GET', headers: { 'Accept': 'application/json' } })
+                        .then(function(r) { if (!r.ok) throw new Error('fetch'); return r.json(); })
+                        .then(function(data) {
+                            selectedRating = parseInt(data.rating || 0);
+                            updateStars(selectedRating);
+                            document.getElementById('commentInput').value = (data.comment || '');
+                            document.getElementById('confirmModal').setAttribute('data-review-edit', 'true');
+                            document.getElementById('btnSettleReview').textContent = '후기 수정하기';
+                        })
+                        .catch(function() { /* ignore */ });
+                }
+            } catch (e) {}
         }
     </script>
 </th:block>

--- a/src/main/resources/templates/workspace/workspace.html
+++ b/src/main/resources/templates/workspace/workspace.html
@@ -997,6 +997,12 @@
             const filename = card ? (card.querySelector('.file-name').textContent.trim()||'') : '';
             renderPatch(el, patch, filename);
         });
+
+        // query param으로 진입 시 후기 모달 자동 오픈
+        const openReviewOnlyModalOnLoad = /*[[${openReviewOnlyModal}]]*/ false;
+        if (openReviewOnlyModalOnLoad) {
+            try { openReviewOnlyModal(); } catch (e) {}
+        }
     </script>
 </th:block>
 


### PR DESCRIPTION
## 🔎 What

- 멘토링 후기 페이지에 '나의 후기' 탭 추가
  - totalCount, 수정 버튼(연필) 존재
  - 수정 기능

### 멘토링 후기 페이지
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/a7928d04-5daf-4527-88be-7e7f9cb2e369" />

### 연필 버튼 누르면 멘토링 수정 모달 뜸 (기존 후기 내용)
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/d3371c71-10e3-422d-b0d0-9c89d9099068" />

### 후기 수정
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8d78d06a-ecfe-42c0-b1d0-45be0f602b87" />

### 수정된 후기 반영됨
<img width="911" height="516" alt="image" src="https://github.com/user-attachments/assets/f32c1589-550a-4a4f-8f70-342f51e9498f" />

## 🔗 Issue

- Closes: #126 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?

