### PR TITLE
[refactor] '내 멘토링' 페이지 멘토링 내역의 버튼 리팩토링 (문구 변경, 버튼제거)

### DIFF
--- a/src/main/resources/templates/my/dashboard/junior.html
+++ b/src/main/resources/templates/my/dashboard/junior.html
@@ -420,7 +420,7 @@
 
                         <!-- 상태 배지 -->
                         <span th:if="${order.status.name() == 'PENDING'}"   class="status-pill status-pending">결제 대기</span>
-                        <span th:if="${order.status.name() == 'PAID'}"      class="status-pill status-paid">PAID</span>
+                        <span th:if="${order.status.name() == 'PAID'}"      class="status-pill status-paid">리뷰 진행중</span>
                         <span th:if="${order.status.name() == 'SETTLED'}"   class="status-pill status-settled">완료</span>
                         <span th:if="${order.status.name() == 'CANCELLED'}" class="status-pill status-cancelled">취소됨</span>
                     </div>
@@ -441,10 +441,7 @@
                     <span th:if="${order.status.name() == 'SETTLED' and order.hasReview}"
                           class="text-mint small fw-semibold">✓ 후기 작성됨</span>
 
-                    <span th:if="${order.status.name() == 'PAID'}"    class="text-secondary small">리뷰 진행중</span>
-                    <span th:if="${order.status.name() == 'PENDING'}" class="text-warning small">결제 대기</span>
-
-                    <a th:href="@{|/orders/${order.orderId}|}" class="btn-action btn-action-outline">상세 →</a>
+                    <a th:href="@{|/orders/${order.orderId}|}" class="btn-action btn-action-outline">워크스페이스 입장 →</a>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/my/dashboard/senior.html
+++ b/src/main/resources/templates/my/dashboard/senior.html
@@ -575,9 +575,6 @@
                     </div>
 
                     <div class="d-flex align-items-center gap-2">
-                        <a th:if="${order.status.name() == 'PAID'}"
-                           th:href="@{|/orders/${order.orderId}|}"
-                           class="btn-action btn-action-mint">리뷰 시작하기 →</a>
 
                         <span th:if="${order.status.name() == 'SETTLED' and order.hasReview}"
                               class="text-mint small fw-semibold">✓ 후기 받음</span>
@@ -585,7 +582,7 @@
                               class="text-secondary small">완료</span>
 
                         <a th:href="@{|/orders/${order.orderId}|}"
-                           class="btn-action btn-action-outline">리포트 보기 →</a>
+                           class="btn-action btn-action-outline">워크스페이스 입장 →</a>
                     </div>
                 </div>
             </th:block>


### PR DESCRIPTION
## 🔎 What

### 시니어 '내 멘토링'
- 상태가 '리뷰 진행중'일 때 '리뷰 시작하기' 버튼 제거
- '리포트 보기' -> '워크스페이스 입장'으로 변경
<img width="700" alt="image" src="https://github.com/user-attachments/assets/63ed3a63-b77c-4fed-86a1-cb53cd321682" />
<img width="700" alt="image" src="https://github.com/user-attachments/assets/8e982bed-9e36-4599-93db-4c24b7f8e212" />

### 주니어 '내 멘토링'
- '상세' -> '워크스페이스 입장'으로 변경
- 주문이 PAID 상태일 땐 '리뷰 진행중'으로 시니어의 화면과 통일
- '리뷰 진행중', '결제 대기'는 상태 배지, 액션(오른쪽)에 둘 다 뜨므로 액션에는 지우기
<img width="1314" height="554" alt="image" src="https://github.com/user-attachments/assets/f09ffc84-aded-4672-a23b-88a3e310190f" />

## 🔗 Issue

- Closes: #128 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?

